### PR TITLE
New way of defining routes

### DIFF
--- a/src/Routes/Route.php
+++ b/src/Routes/Route.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Quantum PHP Framework
+ * 
+ * An open source software development framework for PHP
+ * 
+ * @package Quantum
+ * @author Arman Ag. <arman.ag@softberg.org>
+ * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
+ * @link http://quantum.softberg.org/
+ * @since 1.0.0
+ */
+
+namespace Quantum\Routes;
+
+use Quantum\Routes\Router;
+
+/**
+ * Route Class
+ * 
+ * Route class allows to add new route entries
+ * 
+ * @package Quantum
+ * @subpackage Routes
+ * @category Routes
+ */
+class Route {
+
+    /**
+     * List of routes
+     *
+     * @var array 
+     */
+    private $router;
+
+    /**
+     * Current module
+     * 
+     * @var string 
+     */
+    private $module;
+
+    /**
+     * Class constructor
+     * 
+     * @param Router $router
+     * @param string $module
+     */
+    public function __construct(Router $router, $module) {
+        $this->router = $router;
+        $this->module = $module;
+    }
+
+    /**
+     * Adds new route entry to routes
+     * 
+     * @param string $uri
+     * @param string $method
+     * @param string $controller
+     * @param string $action
+     * @param array $middlewares
+     */
+    public function add($uri, $method, $controller, $action, $middlewares = []) {
+        array_push($this->router->routes, [
+            'uri' => $uri,
+            'method' => $method,
+            'controller' => $controller,
+            'action' => $action,
+            'module' => $this->module,
+            'middlewares' => $middlewares
+        ]);
+    }
+
+}

--- a/src/Routes/Router.php
+++ b/src/Routes/Router.php
@@ -35,19 +35,7 @@ class Router extends RouteController {
      *
      * @var array 
      */
-    private $routes;
-
-    /**
-     * Class constructor
-     * 
-     * Runs the route mapping.
-     * 
-     * @param \Quantum\Routes\ModuleLoader $moduleLoader
-     * @return void
-     */
-    public function __construct(ModuleLoader $moduleLoader) {
-        $this->routes = $moduleLoader->routes;
-    }
+    public $routes = array();
 
     /**
      * Find Route
@@ -58,7 +46,7 @@ class Router extends RouteController {
      * @return void
      * @throws RouteException When repetitive route was found
      */
-	public function findRoute() {
+    public function findRoute() {
         if (isset($_SERVER['REQUEST_URI'])) {
 
             $matched_uris = array();
@@ -66,22 +54,22 @@ class Router extends RouteController {
             $request_uri = preg_replace('/[?]/', '', $_SERVER['REQUEST_URI']);
 
             foreach ($this->routes as $route) {
-                if(trim(urldecode($request_uri), '/') == $route['uri']) {
+                if (trim(urldecode($request_uri), '/') == $route['uri']) {
                     $matched_uris[] = $route['uri'];
                     $route['args'] = [];
                     array_push($routes_group, $route);
                 }
             }
 
-            if(!$matched_uris) {
+            if (!$matched_uris) {
                 foreach ($this->routes as $route) {
                     $route['uri'] = str_replace('/', '\/', $route['uri']);
                     $route['uri'] = preg_replace_callback('/\[(:num)(:([0-9]+))*\](\?)?/', array($this, 'findPattern'), $route['uri']);
                     $route['uri'] = preg_replace_callback('/\[(:alpha)(:([0-9]+))*\](\?)?/', array($this, 'findPattern'), $route['uri']);
                     $route['uri'] = preg_replace_callback('/\[(:any)(:([0-9]+))*\](\?)?/', array($this, 'findPattern'), $route['uri']);
-					
-					$request_uri = parse_url($_SERVER['REQUEST_URI']);
-                    
+
+                    $request_uri = parse_url($_SERVER['REQUEST_URI']);
+
                     preg_match("/^\/" . $route['uri'] . "$/u", urldecode($request_uri['path']), $matches);
 
                     if ($matches) {

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -41,16 +41,19 @@ class Bootstrap {
      * @throws Exception if one of these components fails: Router, Config, Helpers, Libraries, MVC MAnager.
      */
     public static function run() {
-
-        $router = new Router(new ModuleLoader);
-        $mvcManager = new MvcManager();
-
         try {
+            $router = new Router();
+
+            (new ModuleLoader())->loadModules($router);
+
+            $router->findRoute();
+
             Environment::load();
             Config::load();
-            $router->findRoute();
             Helpers::load();
             Libraries::load();
+
+            $mvcManager = new MvcManager();
             $mvcManager->runMvc(Router::$currentRoute);
         } catch (\Exception $e) {
             echo $e->getMessage();


### PR DESCRIPTION
New more flexible way of defining routes with ability to add middle-wares in future 

Not compatible with previous versions, but easy to migrate:

Example:

// Old routes:
return array(
    array ('', 'GET', 'MainController', 'indexAction'),
    array ('[:alpha]', 'GET', 'MainController', 'indexAction'),
    array ('something/[:num]', 'GET', 'SomeController', 'indexAction'),
);

// Awesome routes:
return function($route){
    $route->add('', 'GET', 'MainController', 'indexAction');
    $route->add('[:alpha]', 'GET', 'MainController', 'indexAction');
    $route->add('something/[:num]', 'GET', 'SomeController', 'indexAction');
};