### PR TITLE
Fix PHP 8.4 compatibility: Add void return type to resetBuilderState method

### DIFF
--- a/src/Libraries/Database/Adapters/Sleekdb/SleekDbal.php
+++ b/src/Libraries/Database/Adapters/Sleekdb/SleekDbal.php
@@ -370,7 +370,7 @@ class SleekDbal implements DbalInterface
     /**
      * Resets the builder state
      */
-    protected function resetBuilderState()
+    protected function resetBuilderState(): void
     {
         $this->criterias = [];
         $this->havings = [];


### PR DESCRIPTION
Fix PHP 8.4 compatibility: Add missing void return type to resetBuilderState()

**Problem:**
Running `composer create-project quantum/project project` throws a fatal error:

**PHP Fatal error: Declaration of Quantum\Libraries\Database\Adapters\Sleekdb\SleekDbal::resetBuilderState() must be compatible with Quantum\Libraries\Database\Adapters\Sleekdb\Statements\Result::resetBuilderState(): void**

**Solution:**
Added missing `: void` return type to the `resetBuilderState()` method in `SleekDbal` class to match the abstract method signature in the `Result` trait.

**Files Changed:**
- `src/Libraries/Database/Adapters/Sleekdb/SleekDbal.php` (line 373)
