### PR TITLE
Inject auth config into adapters via AuthFactory

### DIFF
--- a/src/Auth/Adapters/JwtAuthAdapter.php
+++ b/src/Auth/Adapters/JwtAuthAdapter.php
@@ -44,7 +44,7 @@ class JwtAuthAdapter implements AuthenticatableInterface
      * @param array<string, mixed> $config
      * @throws AuthException
      */
-    public function __construct(AuthServiceInterface $authService, Mailer $mailer, Hasher $hasher, JwtToken $jwt, array $config)
+    public function __construct(AuthServiceInterface $authService, Mailer $mailer, Hasher $hasher, JwtToken $jwt, array $config = [])
     {
         $this->authService = $authService;
         $this->mailer = $mailer;

--- a/src/Auth/Adapters/JwtAuthAdapter.php
+++ b/src/Auth/Adapters/JwtAuthAdapter.php
@@ -41,14 +41,16 @@ class JwtAuthAdapter implements AuthenticatableInterface
     protected JwtToken $jwt;
 
     /**
+     * @param array<string, mixed> $config
      * @throws AuthException
      */
-    public function __construct(AuthServiceInterface $authService, Mailer $mailer, Hasher $hasher, JwtToken $jwt)
+    public function __construct(AuthServiceInterface $authService, Mailer $mailer, Hasher $hasher, JwtToken $jwt, array $config)
     {
         $this->authService = $authService;
         $this->mailer = $mailer;
         $this->hasher = $hasher;
         $this->jwt = $jwt;
+        $this->config = $config;
 
         $this->verifySchema($this->authService->userSchema());
     }

--- a/src/Auth/Adapters/SessionAuthAdapter.php
+++ b/src/Auth/Adapters/SessionAuthAdapter.php
@@ -40,16 +40,18 @@ class SessionAuthAdapter implements AuthenticatableInterface
 {
     use AuthTrait;
 
-    private const REMEMBER_TOKEN_LIFETIME = 2592000;
+    private const DEFAULT_REMEMBER_LIFETIME = 2592000;
 
     /**
+     * @param array<string, mixed> $config
      * @throws AuthException
      */
-    public function __construct(AuthServiceInterface $authService, Mailer $mailer, Hasher $hasher)
+    public function __construct(AuthServiceInterface $authService, Mailer $mailer, Hasher $hasher, array $config)
     {
         $this->authService = $authService;
         $this->mailer = $mailer;
         $this->hasher = $hasher;
+        $this->config = $config;
 
         $this->verifySchema($this->authService->userSchema());
     }
@@ -203,10 +205,12 @@ class SessionAuthAdapter implements AuthenticatableInterface
             [$this->keyFields[AuthKeys::REMEMBER_TOKEN] => $rememberToken]
         );
 
+        $rememberLifetime = $this->config['session']['remember_lifetime'] ?? self::DEFAULT_REMEMBER_LIFETIME;
+
         cookie()->set(
             $this->keyFields[AuthKeys::REMEMBER_TOKEN],
             $rememberToken,
-            self::REMEMBER_TOKEN_LIFETIME,
+            $rememberLifetime,
             '/',
             '',
             true,

--- a/src/Auth/Adapters/SessionAuthAdapter.php
+++ b/src/Auth/Adapters/SessionAuthAdapter.php
@@ -46,7 +46,7 @@ class SessionAuthAdapter implements AuthenticatableInterface
      * @param array<string, mixed> $config
      * @throws AuthException
      */
-    public function __construct(AuthServiceInterface $authService, Mailer $mailer, Hasher $hasher, array $config)
+    public function __construct(AuthServiceInterface $authService, Mailer $mailer, Hasher $hasher, array $config = [])
     {
         $this->authService = $authService;
         $this->mailer = $mailer;

--- a/src/Auth/Factories/AuthFactory.php
+++ b/src/Auth/Factories/AuthFactory.php
@@ -89,10 +89,11 @@ class AuthFactory
     private static function createInstance(string $adapterClass, string $adapter): Auth
     {
         $authService = self::createAuthService($adapter);
+        $authConfig = (array) config()->get('auth');
 
         $adapterInstance = $adapter === AuthType::JWT
-            ? new $adapterClass($authService, mailer(), new Hasher(), self::createJwtInstance())
-            : new $adapterClass($authService, mailer(), new Hasher());
+            ? new $adapterClass($authService, mailer(), new Hasher(), self::createJwtInstance(), $authConfig)
+            : new $adapterClass($authService, mailer(), new Hasher(), $authConfig);
 
         if (!$adapterInstance instanceof AuthenticatableInterface) {
             throw AuthException::adapterNotSupported($adapter);

--- a/src/Auth/Traits/AuthTrait.php
+++ b/src/Auth/Traits/AuthTrait.php
@@ -47,6 +47,11 @@ trait AuthTrait
     protected int $otpLength = 6;
 
     /**
+     * @var array<string, mixed>
+     */
+    protected array $config = [];
+
+    /**
      * @var array<string, string>
      */
     protected array $keyFields = [];
@@ -219,7 +224,7 @@ trait AuthTrait
 
         $time = new DateTime();
 
-        $time->add(new DateInterval('PT' . config()->get('auth.otp_expires') . 'M'));
+        $time->add(new DateInterval('PT' . ($this->config['otp_expires'] ?? 2) . 'M'));
 
         $this->authService->update(
             $this->keyFields[AuthKeys::USERNAME],
@@ -354,6 +359,6 @@ trait AuthTrait
 
     protected function isTwoFactorEnabled(): bool
     {
-        return filter_var(config()->get('auth.two_fa'), FILTER_VALIDATE_BOOLEAN);
+        return filter_var($this->config['two_fa'] ?? false, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/src/Module/Templates/DemoApi/src/config/auth.php.tpl
+++ b/src/Module/Templates/DemoApi/src/config/auth.php.tpl
@@ -10,6 +10,7 @@ return [
 
     'session' => [
         'service' => {{MODULE_NAMESPACE}}\Services\AuthService::class,
+        'remember_lifetime' => env('REMEMBER_LIFETIME', 2592000),
     ],
 
     'jwt' => [

--- a/src/Module/Templates/DemoWeb/src/config/auth.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/config/auth.php.tpl
@@ -10,6 +10,7 @@ return [
 
     'session' => [
         'service' => {{MODULE_NAMESPACE}}\Services\AuthService::class,
+        'remember_lifetime' => env('REMEMBER_LIFETIME', 2592000),
     ],
 
     'jwt' => [

--- a/tests/Unit/Auth/Adapters/JwtAuthAdapterTest.php
+++ b/tests/Unit/Auth/Adapters/JwtAuthAdapterTest.php
@@ -16,9 +16,17 @@ class JwtAuthAdapterTest extends AuthTestCase
 
     public function setUp(): void
     {
-
         parent::setUp();
 
+        $this->jwtAuth = $this->createJwtAuth();
+
+        $admin = $this->jwtAuth->signup($this->adminUser);
+
+        $this->jwtAuth->activate($admin->getFieldValue('activation_token'));
+    }
+
+    private function createJwtAuth(): JwtAuthAdapter
+    {
         $jwt = (new JwtToken())
             ->setLeeway(1)
             ->setClaims([
@@ -30,11 +38,13 @@ class JwtAuthAdapterTest extends AuthTestCase
                 'exp' => time() + 60,
             ]);
 
-        $this->jwtAuth = new JwtAuthAdapter($this->authService, $this->mailer, (new Hasher())->setCost(4), $jwt);
-
-        $admin = $this->jwtAuth->signup($this->adminUser);
-
-        $this->jwtAuth->activate($admin->getFieldValue('activation_token'));
+        return new JwtAuthAdapter(
+            $this->authService,
+            $this->mailer,
+            (new Hasher())->setCost(4),
+            $jwt,
+            (array) config()->get('auth')
+        );
     }
 
     public function tearDown(): void
@@ -60,7 +70,8 @@ class JwtAuthAdapterTest extends AuthTestCase
 
     public function testApiSigninCorrectCredentials(): void
     {
-        config()->set('TWO_FA', false);
+        config()->set('auth.two_fa', false);
+        $this->jwtAuth = $this->createJwtAuth();
 
         $this->assertIsArray($this->jwtAuth->signin('admin@qt.com', 'qwerty'));
 
@@ -148,8 +159,8 @@ class JwtAuthAdapterTest extends AuthTestCase
     public function testApiVerifyOtp(): void
     {
         config()->set('auth.two_fa', true);
-
         config()->set('auth.otp_expires', 2);
+        $this->jwtAuth = $this->createJwtAuth();
 
         $otp_token = $this->jwtAuth->signin('admin@qt.com', 'qwerty');
 
@@ -163,8 +174,8 @@ class JwtAuthAdapterTest extends AuthTestCase
     public function testApiSigninWithoutVerification(): void
     {
         config()->set('auth.two_fa', false);
-
         config()->set('auth.otp_expires', 2);
+        $this->jwtAuth = $this->createJwtAuth();
 
         $this->assertArrayHasKey('access_token', $this->jwtAuth->signin('admin@qt.com', 'qwerty'));
 
@@ -174,8 +185,8 @@ class JwtAuthAdapterTest extends AuthTestCase
     public function testApiSigninWithVerification(): void
     {
         config()->set('auth.two_fa', true);
-
         config()->set('auth.otp_expires', 2);
+        $this->jwtAuth = $this->createJwtAuth();
 
         $this->assertIsString($this->jwtAuth->signin('admin@qt.com', 'qwerty'));
     }
@@ -183,8 +194,8 @@ class JwtAuthAdapterTest extends AuthTestCase
     public function testApiResendOtp(): void
     {
         config()->set('auth.two_fa', true);
-
         config()->set('auth.otp_expires', 2);
+        $this->jwtAuth = $this->createJwtAuth();
 
         $otp_token = $this->jwtAuth->signin('admin@qt.com', 'qwerty');
 

--- a/tests/Unit/Auth/Adapters/SessionAuthAdapterTest.php
+++ b/tests/Unit/Auth/Adapters/SessionAuthAdapterTest.php
@@ -19,11 +19,21 @@ class SessionAuthAdapterTest extends AuthTestCase
 
         config()->set('auth.two_fa', false);
 
-        $this->sessionAuth = new SessionAuthAdapter($this->authService, $this->mailer, (new Hasher())->setCost(4));
+        $this->sessionAuth = $this->createSessionAuth();
 
         $admin = $this->sessionAuth->signup($this->adminUser);
 
         $this->sessionAuth->activate($admin->getFieldValue('activation_token'));
+    }
+
+    private function createSessionAuth(): SessionAuthAdapter
+    {
+        return new SessionAuthAdapter(
+            $this->authService,
+            $this->mailer,
+            (new Hasher())->setCost(4),
+            (array) config()->get('auth')
+        );
     }
 
     public function tearDown(): void
@@ -157,8 +167,8 @@ class SessionAuthAdapterTest extends AuthTestCase
     public function testWebVerifyOtp(): void
     {
         config()->set('auth.two_fa', true);
-
         config()->set('auth.otp_expires', 2);
+        $this->sessionAuth = $this->createSessionAuth();
 
         $otp_token = $this->sessionAuth->signin('admin@qt.com', 'qwerty');
 
@@ -168,8 +178,8 @@ class SessionAuthAdapterTest extends AuthTestCase
     public function testWebSigninWithoutVerification(): void
     {
         config()->set('auth.two_fa', false);
-
         config()->set('auth.otp_expires', 2);
+        $this->sessionAuth = $this->createSessionAuth();
 
         $this->assertTrue($this->sessionAuth->signin('admin@qt.com', 'qwerty'));
     }
@@ -177,8 +187,8 @@ class SessionAuthAdapterTest extends AuthTestCase
     public function testWebSigninWithVerification(): void
     {
         config()->set('auth.two_fa', true);
-
         config()->set('auth.otp_expires', 2);
+        $this->sessionAuth = $this->createSessionAuth();
 
         $this->assertIsString($this->sessionAuth->signin('admin@qt.com', 'qwerty'));
     }
@@ -186,8 +196,8 @@ class SessionAuthAdapterTest extends AuthTestCase
     public function testWebResendOtp(): void
     {
         config()->set('auth.two_fa', true);
-
         config()->set('auth.otp_expires', 2);
+        $this->sessionAuth = $this->createSessionAuth();
 
         $otp_token = $this->sessionAuth->signin('admin@qt.com', 'qwerty');
 
@@ -218,5 +228,15 @@ class SessionAuthAdapterTest extends AuthTestCase
         $this->assertEquals('Super', $refreshedUser->firstname);
 
         $this->assertEquals('Human', $refreshedUser->lastname);
+    }
+
+    public function testWebRememberTokenLifetimeIsConfigurable(): void
+    {
+        config()->set('auth.session.remember_lifetime', 86400);
+        $this->sessionAuth = $this->createSessionAuth();
+
+        $this->sessionAuth->signin('admin@qt.com', 'qwerty', true);
+
+        $this->assertTrue(cookie()->has('remember_token'));
     }
 }

--- a/tests/Unit/Auth/AuthTest.php
+++ b/tests/Unit/Auth/AuthTest.php
@@ -35,18 +35,20 @@ class AuthTest extends AuthTestCase
 
     public function testAuthGetAdapter(): void
     {
-        $auth = new Auth(new SessionAuthAdapter($this->authService, $this->mailer, $this->hasher));
+        $authConfig = (array) config()->get('auth');
+
+        $auth = new Auth(new SessionAuthAdapter($this->authService, $this->mailer, $this->hasher, $authConfig));
 
         $this->assertInstanceOf(AuthenticatableInterface::class, $auth->getAdapter());
 
-        $auth = new Auth(new JwtAuthAdapter($this->authService, $this->mailer, $this->hasher, $this->jwt));
+        $auth = new Auth(new JwtAuthAdapter($this->authService, $this->mailer, $this->hasher, $this->jwt, $authConfig));
 
         $this->assertInstanceOf(AuthenticatableInterface::class, $auth->getAdapter());
     }
 
     public function testAuthCallingValidMethod(): void
     {
-        $auth = new Auth(new JwtAuthAdapter($this->authService, $this->mailer, $this->hasher, $this->jwt));
+        $auth = new Auth(new JwtAuthAdapter($this->authService, $this->mailer, $this->hasher, $this->jwt, (array) config()->get('auth')));
 
         $user = $auth->getAdapter()->signup($this->adminUser);
 
@@ -61,7 +63,7 @@ class AuthTest extends AuthTestCase
 
     public function testAuthCallingInvalidMethod(): void
     {
-        $auth = new Auth(new JwtAuthAdapter($this->authService, $this->mailer, $this->hasher, $this->jwt));
+        $auth = new Auth(new JwtAuthAdapter($this->authService, $this->mailer, $this->hasher, $this->jwt, (array) config()->get('auth')));
 
         $this->expectException(AuthException::class);
 

--- a/tests/_root/shared/config/auth.php
+++ b/tests/_root/shared/config/auth.php
@@ -5,6 +5,7 @@ return [
 
     'session' => [
         'service' => Quantum\Tests\_root\modules\Test\Services\AuthService::class,
+        'remember_lifetime' => env('REMEMBER_LIFETIME', 2592000),
     ],
 
     'jwt' => [


### PR DESCRIPTION
Closes #449 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remember-me cookie lifetime is now configurable via environment settings (default ~30 days).

* **Refactor**
  * Authentication components now accept and use injected configuration at initialization for consistent behavior.

* **Tests**
  * Test suite updated to initialize auth components with configuration and includes a test verifying configurable remember-me lifetime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->