### PR TITLE
[#459] Refactor `view()` helper to service locator and rename `QtView` to `View`

### DIFF
--- a/src/App/Stages/InitDebuggerStage.php
+++ b/src/App/Stages/InitDebuggerStage.php
@@ -17,11 +17,7 @@ declare(strict_types=1);
 namespace Quantum\App\Stages;
 
 use Quantum\App\Contracts\BootStageInterface;
-use Quantum\Di\Exceptions\DiException;
-use Quantum\Debugger\Debugger;
 use Quantum\App\AppContext;
-use ReflectionException;
-use Quantum\Di\Di;
 
 /**
  * Class InitDebuggerStage
@@ -29,15 +25,8 @@ use Quantum\Di\Di;
  */
 class InitDebuggerStage implements BootStageInterface
 {
-    /**
-     * @throws DiException|ReflectionException
-     */
     public function process(AppContext $context): void
     {
-        if (!Di::isRegistered(Debugger::class)) {
-            Di::register(Debugger::class);
-        }
-
-        Di::get(Debugger::class)->initStore();
+        debugbar()->initStore();
     }
 }

--- a/src/App/Traits/WebAppTrait.php
+++ b/src/App/Traits/WebAppTrait.php
@@ -100,10 +100,8 @@ trait WebAppTrait
      */
     private function logDebugInfo(): void
     {
-        $debugger = Di::get(Debugger::class);
-
-        if ($debugger->isEnabled()) {
-            $debugger->addToStoreCell(Debugger::HOOKS, 'info', hook()->getRegistered());
+        if (debugbar()->isEnabled()) {
+            debugbar()->addToStoreCell(Debugger::HOOKS, 'info', hook()->getRegistered());
         }
     }
 

--- a/src/App/Traits/WebAppTrait.php
+++ b/src/App/Traits/WebAppTrait.php
@@ -100,8 +100,10 @@ trait WebAppTrait
      */
     private function logDebugInfo(): void
     {
-        if (debugbar()->isEnabled()) {
-            debugbar()->addToStoreCell(Debugger::HOOKS, 'info', hook()->getRegistered());
+        $debugbar = debugbar();
+
+        if ($debugbar->isEnabled()) {
+            $debugbar->addToStoreCell(Debugger::HOOKS, 'info', hook()->getRegistered());
         }
     }
 

--- a/src/Logger/Adapters/MessageAdapter.php
+++ b/src/Logger/Adapters/MessageAdapter.php
@@ -17,11 +17,7 @@ declare(strict_types=1);
 namespace Quantum\Logger\Adapters;
 
 use Quantum\Logger\Contracts\ReportableInterface;
-use Quantum\Di\Exceptions\DiException;
-use DebugBar\DebugBarException;
 use Quantum\Debugger\Debugger;
-use ReflectionException;
-use Quantum\Di\Di;
 
 /**
  * Class MessageAdapter
@@ -29,23 +25,11 @@ use Quantum\Di\Di;
  */
 class MessageAdapter implements ReportableInterface
 {
-    /**
-     * @param array<string, mixed>|null $context
-     * @throws DebugBarException
-     */
-
-    /**
-     * @throws DiException|ReflectionException
-     */
     public function report(string $level, string $message, ?array $context = []): void
     {
         $tab = $context['tab'] ?? Debugger::MESSAGES;
 
-        if (!Di::isRegistered(Debugger::class)) {
-            Di::register(Debugger::class);
-        }
-
-        $debugger = Di::get(Debugger::class);
+        $debugger = debugbar();
 
         if ($debugger->isEnabled()) {
             $debugger->addToStoreCell($tab, $level, $message);

--- a/src/Module/Templates/DefaultWeb/src/Views/layouts/main.php.tpl
+++ b/src/Module/Templates/DefaultWeb/src/Views/layouts/main.php.tpl
@@ -12,7 +12,7 @@
     </head>
     <body>
 
-        <main><?php echo view() ?></main>
+        <main><?= view()->getContent() ?></main>
 
         <?= debugbar()->render() ?>
 

--- a/src/Module/Templates/DemoWeb/src/Controllers/BaseController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/BaseController.php.tpl
@@ -16,7 +16,7 @@ namespace {{MODULE_NAMESPACE}}\Controllers;
 
 use Quantum\View\Factories\ViewFactory;
 use Quantum\Asset\Asset;
-use Quantum\View\QtView;
+use Quantum\View\View;
 
 /**
  * Class BaseController
@@ -26,9 +26,9 @@ abstract class BaseController
 {
 
     /**
-    * @var QtView
+    * @var View
     */
-    protected QtView $view;
+    protected View $view;
 
     public function __before()
     {

--- a/src/Module/Templates/DemoWeb/src/Views/layouts/main.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Views/layouts/main.php.tpl
@@ -12,7 +12,7 @@
     <body>
         <header><?php echo partial('partials/navbar') ?></header>
         
-        <main><?php echo view() ?></main>
+        <main><?= view()->getContent() ?></main>
         
         <footer class="page-footer"><?php echo partial('partials/footer') ?></footer>
         

--- a/src/Module/Templates/Toolkit/src/Controllers/BaseController.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Controllers/BaseController.php.tpl
@@ -16,7 +16,7 @@ namespace Modules\Toolkit\Controllers;
 
 use Quantum\View\Factories\ViewFactory;
 use Quantum\Asset\Asset;
-use Quantum\View\QtView;
+use Quantum\View\View;
 
 /**
  * Class BaseController
@@ -40,9 +40,9 @@ class BaseController
     protected const CURRENT_PAGE = 1;
 
     /**
-     * @var QtView
+     * @var View
      */
-    protected QtView $view;
+    protected View $view;
 
     /**
      * Works before an action

--- a/src/Module/Templates/Toolkit/src/Views/layouts/iframe.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Views/layouts/iframe.php.tpl
@@ -17,7 +17,7 @@
 <body>
 
 <main>
-    <?php echo view() ?>
+    <?= view()->getContent() ?>
 </main>
 
 <?php assets("js") ?>

--- a/src/Module/Templates/Toolkit/src/Views/layouts/main.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Views/layouts/main.php.tpl
@@ -29,7 +29,7 @@
 
 <main>
     <div id="toolkit-content">
-        <?php echo view() ?>
+        <?= view()->getContent() ?>
     </div>
 </main>
 

--- a/src/View/Factories/ViewFactory.php
+++ b/src/View/Factories/ViewFactory.php
@@ -21,24 +21,23 @@ use Quantum\Config\Exceptions\ConfigException;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Di\Exceptions\DiException;
 use Quantum\ResourceCache\ViewCache;
-use Quantum\Debugger\Debugger;
-use Quantum\View\QtView;
 use ReflectionException;
+use Quantum\View\View;
 use Quantum\Di\Di;
 
 /**
  * Class ViewFactory
  * @package Quantum\View
- * @mixin QtView
+ * @mixin View
  */
 class ViewFactory
 {
-    private ?QtView $instance = null;
+    private ?View $instance = null;
 
     /**
      * @throws ConfigException|BaseException|DiException|ReflectionException
      */
-    public static function get(): QtView
+    public static function get(): View
     {
         if (!Di::isRegistered(self::class)) {
             Di::register(self::class);
@@ -50,17 +49,17 @@ class ViewFactory
     /**
      * @throws ConfigException|BaseException|DiException|ReflectionException
      */
-    public function resolve(): QtView
+    public function resolve(): View
     {
         if ($this->instance === null) {
             if (!Di::isRegistered(ViewCache::class)) {
                 Di::register(ViewCache::class);
             }
 
-            $this->instance = new QtView(
+            $this->instance = new View(
                 RendererFactory::get(),
                 asset(),
-                Di::get(Debugger::class),
+                debugbar(),
                 Di::get(ViewCache::class)
             );
         }

--- a/src/View/Helpers/view.php
+++ b/src/View/Helpers/view.php
@@ -16,20 +16,20 @@ declare(strict_types=1);
 
 use League\CommonMark\Exception\CommonMarkException;
 use Quantum\Config\Exceptions\ConfigException;
-use Quantum\View\Exceptions\ViewException;
 use League\CommonMark\CommonMarkConverter;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\View\Factories\ViewFactory;
 use Quantum\Di\Exceptions\DiException;
 use Quantum\View\RawParam;
+use Quantum\View\View;
 
 /**
- * Rendered view
- * @throws ViewException|ConfigException|DiException|BaseException|ReflectionException
+ * Gets the View instance
+ * @throws ConfigException|DiException|BaseException|ReflectionException
  */
-function view(): ?string
+function view(): View
 {
-    return ViewFactory::get()->getView();
+    return ViewFactory::get();
 }
 
 /**
@@ -39,7 +39,7 @@ function view(): ?string
  */
 function partial(string $partial, array $args = []): string
 {
-    return ViewFactory::get()->renderPartial($partial, $args);
+    return view()->renderPartial($partial, $args);
 }
 
 /**
@@ -52,7 +52,7 @@ function partial(string $partial, array $args = []): string
  */
 function view_param(string $key)
 {
-    return ViewFactory::get()->getParam($key);
+    return view()->getParam($key);
 }
 
 /**

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -31,10 +31,10 @@ use ReflectionException;
 use Psr\Log\LogLevel;
 
 /**
- * Class QtView
+ * Class View
  * @package Quantum\View
  */
-class QtView
+class View
 {
     private Renderer $renderer;
 
@@ -221,10 +221,10 @@ class QtView
     }
 
     /**
-     * Gets the rendered view.
+     * Gets the rendered view content.
      * @throws ViewException
      */
-    public function getView(): ?string
+    public function getContent(): ?string
     {
         if ($this->viewContent === null) {
             throw ViewException::viewNotRendered();

--- a/tests/Unit/View/Factories/ViewFactoryTest.php
+++ b/tests/Unit/View/Factories/ViewFactoryTest.php
@@ -4,7 +4,7 @@ namespace Quantum\Tests\Unit\View\Factories;
 
 use Quantum\View\Factories\ViewFactory;
 use Quantum\Tests\Unit\AppTestCase;
-use Quantum\View\QtView;
+use Quantum\View\View;
 use Quantum\Di\Di;
 
 class ViewFactoryTest extends AppTestCase
@@ -26,7 +26,7 @@ class ViewFactoryTest extends AppTestCase
 
     public function testGetInstance(): void
     {
-        $this->assertInstanceOf(QtView::class, ViewFactory::get());
+        $this->assertInstanceOf(View::class, ViewFactory::get());
     }
 
     public function testResolveReturnsSameInstance(): void

--- a/tests/Unit/View/Helpers/ViewHelperTest.php
+++ b/tests/Unit/View/Helpers/ViewHelperTest.php
@@ -6,11 +6,11 @@ use Quantum\View\Factories\ViewFactory;
 use Quantum\Router\MatchedRoute;
 use Quantum\Router\Route;
 use Quantum\Tests\Unit\AppTestCase;
-use Quantum\View\QtView;
+use Quantum\View\View;
 
 class ViewHelperTest extends AppTestCase
 {
-    private QtView $view;
+    private View $view;
 
     public function setUp(): void
     {
@@ -36,13 +36,18 @@ class ViewHelperTest extends AppTestCase
         $this->view->setLayout(null);
     }
 
-    public function testView(): void
+    public function testViewReturnsInstance(): void
+    {
+        $this->assertInstanceOf(View::class, view());
+    }
+
+    public function testViewGetContent(): void
     {
         $this->view->setLayout('layout');
 
         $this->view->render('index');
 
-        $this->assertEquals('<p>Hello World, this is rendered html view</p>', view());
+        $this->assertEquals('<p>Hello World, this is rendered html view</p>', view()->getContent());
     }
 
     public function testPartial(): void

--- a/tests/Unit/View/ViewTest.php
+++ b/tests/Unit/View/ViewTest.php
@@ -6,14 +6,14 @@ use Quantum\View\Exceptions\ViewException;
 use Quantum\View\Factories\ViewFactory;
 use Quantum\Tests\Unit\AppTestCase;
 use Quantum\Router\MatchedRoute;
-use Quantum\View\QtView;
 use Quantum\View\RawParam;
 use Quantum\Router\Route;
+use Quantum\View\View;
 use Quantum\Di\Di;
 
-class QtViewTest extends AppTestCase
+class ViewTest extends AppTestCase
 {
-    private QtView $view;
+    private View $view;
 
     public function setUp(): void
     {
@@ -126,13 +126,13 @@ class QtViewTest extends AppTestCase
 
         $this->view->render('index', ['name' => 'Lorem Ipsum']);
 
-        $this->assertEquals('<p>Hello Lorem Ipsum, this is rendered html view</p>', $this->view->getView());
+        $this->assertEquals('<p>Hello Lorem Ipsum, this is rendered html view</p>', $this->view->getContent());
 
         $this->view->setParam('name', 'dolor sit amet');
 
         $this->view->render('index');
 
-        $this->assertEquals('<p>Hello dolor sit amet, this is rendered html view</p>', $this->view->getView());
+        $this->assertEquals('<p>Hello dolor sit amet, this is rendered html view</p>', $this->view->getContent());
     }
 
     public function testRenderWithEscapedHtmlData(): void
@@ -143,7 +143,7 @@ class QtViewTest extends AppTestCase
 
         $this->view->render('post');
 
-        $this->assertEquals('&lt;h1&gt;Hello&lt;/h1&gt;', $this->view->getView());
+        $this->assertEquals('&lt;h1&gt;Hello&lt;/h1&gt;', $this->view->getContent());
     }
 
     public function testRenderWithUnEscapedHtmlData(): void
@@ -154,7 +154,7 @@ class QtViewTest extends AppTestCase
 
         $this->view->render('post');
 
-        $this->assertEquals('<h1>Hello</h1>', $this->view->getView());
+        $this->assertEquals('<h1>Hello</h1>', $this->view->getContent());
     }
 
     public function testRenderPartial(): void

--- a/tests/_root/modules/Test/Views/layout.php
+++ b/tests/_root/modules/Test/Views/layout.php
@@ -1,6 +1,6 @@
 <html>
 <head></head>
 <body>
-<?php echo view() ?>
+<?= view()->getContent() ?>
 </body>
 </html>

--- a/tests/_root/modules/Test/Views/layout.twig.php
+++ b/tests/_root/modules/Test/Views/layout.twig.php
@@ -1,6 +1,6 @@
 <html>
 <head></head>
 <body>
-{{ view() }}
+{{ view().getContent() }}
 </body>
 </html>


### PR DESCRIPTION
Closes #459 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined debugger initialization through helper functions for improved code clarity.
  * Enhanced view rendering with explicit content retrieval methods for better consistency.
  * Updated internal view system architecture for improved maintainability across application templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->