### PR TITLE
[#460] Introduce db() helper to encapsulate Database DI lookup

### DIFF
--- a/src/Database/Helpers/db.php
+++ b/src/Database/Helpers/db.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Quantum PHP Framework
+ *
+ * An open source software development framework for PHP
+ *
+ * @package Quantum
+ * @author Arman Ag. <arman.ag@softberg.org>
+ * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
+ * @link http://quantum.softberg.org/
+ * @since 3.0.0
+ */
+
+use Quantum\Database\Database;
+use Quantum\Di\Di;
+
+/**
+ * Gets the Database instance from DI
+ */
+function db(): Database
+{
+    if (!Di::isRegistered(Database::class)) {
+        Di::register(Database::class);
+    }
+
+    return Di::get(Database::class);
+}

--- a/src/Database/Traits/RelationalTrait.php
+++ b/src/Database/Traits/RelationalTrait.php
@@ -16,8 +16,6 @@ declare(strict_types=1);
 
 namespace Quantum\Database\Traits;
 
-use Quantum\Database\Database;
-use Quantum\Di\Di;
 use Quantum\Di\Exceptions\DiException;
 use ReflectionException;
 
@@ -87,10 +85,6 @@ trait RelationalTrait
      */
     protected static function resolveQuery(string $method, string $query = '', array $parameters = [])
     {
-        if (!Di::isRegistered(Database::class)) {
-            Di::register(Database::class);
-        }
-
-        return Di::get(Database::class)->getOrmClass()::$method($query, $parameters);
+        return db()->getOrmClass()::$method($query, $parameters);
     }
 }

--- a/src/Database/Traits/TransactionTrait.php
+++ b/src/Database/Traits/TransactionTrait.php
@@ -18,9 +18,7 @@ namespace Quantum\Database\Traits;
 
 use Quantum\Database\Exceptions\DatabaseException;
 use Quantum\App\Exceptions\BaseException;
-use Quantum\Database\Database;
 use ReflectionException;
-use Quantum\Di\Di;
 use Throwable;
 
 /**
@@ -64,11 +62,7 @@ trait TransactionTrait
      */
     protected static function resolveTransaction(string $method)
     {
-        if (!Di::isRegistered(Database::class)) {
-            Di::register(Database::class);
-        }
-
-        $db = Di::get(Database::class)->getOrmClass();
+        $db = db()->getOrmClass();
 
         if (!method_exists($db, $method)) {
             throw DatabaseException::methodNotSupported($method, self::class);

--- a/src/Migration/MigrationManager.php
+++ b/src/Migration/MigrationManager.php
@@ -28,7 +28,6 @@ use Quantum\Di\Exceptions\DiException;
 use Quantum\Storage\FileSystem;
 use Quantum\Database\Database;
 use ReflectionException;
-use Quantum\Di\Di;
 
 /**
  * Class MigrationManager
@@ -77,11 +76,7 @@ class MigrationManager
     {
         $this->fs = FileSystemFactory::get();
 
-        if (!Di::isRegistered(Database::class)) {
-            Di::register(Database::class);
-        }
-
-        $this->db = Di::get(Database::class);
+        $this->db = db();
 
         $this->tableFactory = new TableFactory();
 

--- a/src/Model/Factories/ModelFactory.php
+++ b/src/Model/Factories/ModelFactory.php
@@ -20,11 +20,9 @@ use Quantum\Database\Contracts\DbalInterface;
 use Quantum\Model\Exceptions\ModelException;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Di\Exceptions\DiException;
-use Quantum\Database\Database;
 use Quantum\Model\DbModel;
 use Quantum\Model\Model;
 use ReflectionException;
-use Quantum\Di\Di;
 
 /**
  * Class ModelFactory
@@ -97,7 +95,7 @@ class ModelFactory
     /**
      * @param array<string> $foreignKeys
      * @param array<string> $hidden
-     * @throws DiException|BaseException|ReflectionException
+     * @throws DiException|BaseException
      */
     protected static function createOrmInstance(
         string $table,
@@ -106,11 +104,7 @@ class ModelFactory
         array  $foreignKeys = [],
         array  $hidden = []
     ): DbalInterface {
-        if (!Di::isRegistered(Database::class)) {
-            Di::register(Database::class);
-        }
-
-        $ormClass = Di::get(Database::class)->getOrmClass();
+        $ormClass = db()->getOrmClass();
 
         $instance = new $ormClass(
             $table,

--- a/src/Model/Factories/ModelFactory.php
+++ b/src/Model/Factories/ModelFactory.php
@@ -95,7 +95,7 @@ class ModelFactory
     /**
      * @param array<string> $foreignKeys
      * @param array<string> $hidden
-     * @throws DiException|BaseException
+     * @throws DiException|BaseException|ReflectionException
      */
     protected static function createOrmInstance(
         string $table,

--- a/tests/Unit/Database/Helpers/DbHelperTest.php
+++ b/tests/Unit/Database/Helpers/DbHelperTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Quantum\Tests\Unit\Database\Helpers;
+
+use Quantum\Tests\Unit\AppTestCase;
+use Quantum\Database\Database;
+
+class DbHelperTest extends AppTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testDbHelperReturnsDatabaseInstance(): void
+    {
+        $this->assertInstanceOf(Database::class, db());
+    }
+
+    public function testDbHelperReturnsSameInstance(): void
+    {
+        $first = db();
+        $second = db();
+
+        $this->assertSame($first, $second);
+    }
+}

--- a/tests/Unit/Database/Helpers/DbHelperTest.php
+++ b/tests/Unit/Database/Helpers/DbHelperTest.php
@@ -4,14 +4,10 @@ namespace Quantum\Tests\Unit\Database\Helpers;
 
 use Quantum\Tests\Unit\AppTestCase;
 use Quantum\Database\Database;
+use Quantum\Di\Di;
 
 class DbHelperTest extends AppTestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function testDbHelperReturnsDatabaseInstance(): void
     {
         $this->assertInstanceOf(Database::class, db());
@@ -23,5 +19,14 @@ class DbHelperTest extends AppTestCase
         $second = db();
 
         $this->assertSame($first, $second);
+    }
+
+    public function testDbHelperLazilyRegistersDatabase(): void
+    {
+        Di::resetContainer();
+
+        $this->assertFalse(Di::isRegistered(Database::class));
+        $this->assertInstanceOf(Database::class, db());
+        $this->assertTrue(Di::isRegistered(Database::class));
     }
 }

--- a/tests/Unit/View/ViewTest.php
+++ b/tests/Unit/View/ViewTest.php
@@ -117,6 +117,8 @@ class ViewTest extends AppTestCase
 
         $this->assertIsString($renderedView);
 
+        $renderedView = str_replace("\n", PHP_EOL, $renderedView);
+
         $this->assertEquals('<html>' . PHP_EOL . '<head></head>' . PHP_EOL . '<body>' . PHP_EOL . '<p>Hello World, this is rendered html view</p></body>' . PHP_EOL . '</html>' . PHP_EOL, $renderedView);
     }
 


### PR DESCRIPTION
Closes #460 

- Create src/Database/Helpers/db.php with db() service-locator helper
- Replace DI boilerplate in RelationalTrait, TransactionTrait, ModelFactory, and MigrationManager with db() calls
- Add DbHelperTest covering instance type and singleton behavior
- Normalize line endings in ViewTest::testRenderWithLayout to fix cross-platform test failure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global `db()` helper function for convenient access to the database instance throughout the application.

* **Tests**
  * Added comprehensive unit test coverage for the database helper, verifying correct instantiation and consistency across multiple calls.
  * Fixed platform-specific line break handling in view rendering tests.

* **Chores**
  * Refactored internal database resolution patterns across multiple components to use the new database helper function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->