### PR TITLE
[#462] Normalize router helper surface through Request proxies

### DIFF
--- a/src/App/Adapters/WebAppAdapter.php
+++ b/src/App/Adapters/WebAppAdapter.php
@@ -84,7 +84,7 @@ class WebAppAdapter extends AppAdapter
 
             [$request, $response] = (new MiddlewareManager($matchedRoute))->applyMiddlewares(request(), response());
 
-            if ($this->setupViewCache()->serveCachedView(route_uri() ?? '', $response)) {
+            if ($this->setupViewCache()->serveCachedView(request()->getUri() ?? '', $response)) {
                 stop();
             }
 

--- a/src/App/Helpers/misc.php
+++ b/src/App/Helpers/misc.php
@@ -83,31 +83,6 @@ function is_debug_mode(): bool
 }
 
 /**
- * Gets the caller class
- */
-function get_caller_class(int $index = 2): ?string
-{
-    $caller = debug_backtrace();
-    $caller = $caller[$index];
-
-    return $caller['class'] ?? null;
-}
-
-/**
- * Gets the caller function
- */
-function get_caller_function(int $index = 2): ?string
-{
-    $trace = debug_backtrace();
-
-    if (!isset($trace[$index])) {
-        return null;
-    }
-
-    return $trace[$index]['function'];
-}
-
-/**
  * Exports the variable
  * @param mixed $var
  * @throws ExceptionInterface

--- a/src/Console/Commands/OpenApiCommand.php
+++ b/src/Console/Commands/OpenApiCommand.php
@@ -124,12 +124,12 @@ class OpenApiCommand extends QtCommand
             return;
         }
 
-        if (route_group_exists('openapi', $module) && $this->fs->exists($modulePath . DS . 'resources' . DS . 'openApi' . DS . 'spec.json')) {
+        if (request()->routeGroupExists('openapi', $module) && $this->fs->exists($modulePath . DS . 'resources' . DS . 'openApi' . DS . 'spec.json')) {
             $this->error('The Open API specifications already installed for `' . ucfirst($module) . '` module');
             return;
         }
 
-        if (!route_group_exists('openapi', $module)) {
+        if (!request()->routeGroupExists('openapi', $module)) {
             $routeContent = $this->fs->get($routes);
 
             if ($routeContent !== false) {

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -193,7 +193,7 @@ class Request
     {
         $baseUrl = config()->get('app.base_url');
 
-        $prefix = route_prefix();
+        $prefix = $this->getRoutePrefix();
         $modulePrefix = ($withModulePrefix && !in_array($prefix, [null, '', '0'], true)) ? '/' . $prefix : '';
 
         if ($baseUrl) {

--- a/src/Http/Traits/Request/Route.php
+++ b/src/Http/Traits/Request/Route.php
@@ -73,9 +73,9 @@ trait Route
         return $this->route ? $this->route->getRoute()->getPattern() : null;
     }
 
-    public function getCompiledRoutePattern(): string
+    public function getCompiledRoutePattern(): ?string
     {
-        return $this->route ? ($this->route->getRoute()->getCompiledPattern() ?? '') : '';
+        return $this->route ? $this->route->getRoute()->getCompiledPattern() : null;
     }
 
     /**

--- a/src/Http/Traits/Request/Route.php
+++ b/src/Http/Traits/Request/Route.php
@@ -16,7 +16,11 @@ declare(strict_types=1);
 
 namespace Quantum\Http\Traits\Request;
 
+use Quantum\Router\Route as RouterRoute;
+use Quantum\Router\RouteCollection;
 use Quantum\Router\MatchedRoute;
+use Quantum\Di\Di;
+use Closure;
 
 /**
  * Trait Route
@@ -36,4 +40,126 @@ trait Route
         return $this->route;
     }
 
+    /**
+     * @return array<int|string, mixed>|null
+     */
+    public function getCurrentMiddlewares(): ?array
+    {
+        return $this->route ? $this->route->getRoute()->getMiddlewares() : null;
+    }
+
+    public function getCurrentModule(): ?string
+    {
+        return $this->route ? $this->route->getRoute()->getModule() : null;
+    }
+
+    public function getCurrentController(): ?string
+    {
+        return $this->route ? $this->route->getRoute()->getController() : null;
+    }
+
+    public function getCurrentAction(): ?string
+    {
+        return $this->route ? $this->route->getRoute()->getAction() : null;
+    }
+
+    public function getRouteCallback(): ?Closure
+    {
+        return $this->route ? $this->route->getRoute()->getClosure() : null;
+    }
+
+    public function getCurrentRoutePattern(): ?string
+    {
+        return $this->route ? $this->route->getRoute()->getPattern() : null;
+    }
+
+    public function getCompiledRoutePattern(): string
+    {
+        return $this->route ? ($this->route->getRoute()->getCompiledPattern() ?? '') : '';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getRouteParams(): array
+    {
+        return $this->route ? $this->route->getParams() : [];
+    }
+
+    /**
+     * @return mixed|null
+     */
+    public function getRouteParam(string $name)
+    {
+        $params = $this->getRouteParams();
+
+        return $params[$name] ?? null;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getRouteCacheSettings(): ?array
+    {
+        return $this->route ? $this->route->getRoute()->getCache() : null;
+    }
+
+    public function getRouteName(): ?string
+    {
+        return $this->route ? $this->route->getRoute()->getName() : null;
+    }
+
+    public function getRoutePrefix(): ?string
+    {
+        return $this->route ? $this->route->getRoute()->getPrefix() : null;
+    }
+
+    public function findRouteByName(string $name, string $module): ?RouterRoute
+    {
+        if (!Di::isRegistered(RouteCollection::class)) {
+            return null;
+        }
+
+        $collection = Di::get(RouteCollection::class);
+
+        foreach ($collection->all() as $route) {
+            if (
+                $route->getName() !== null &&
+                strcasecmp($route->getName(), $name) === 0 &&
+                strcasecmp((string) $route->getModule(), $module) === 0
+            ) {
+                return $route;
+            }
+        }
+
+        return null;
+    }
+
+    public function routeGroupExists(string $name, string $module): bool
+    {
+        if (!Di::isRegistered(RouteCollection::class)) {
+            return false;
+        }
+
+        $collection = Di::get(RouteCollection::class);
+
+        foreach ($collection->all() as $route) {
+            if (
+                $route->getGroup() !== null &&
+                strcasecmp($route->getGroup(), $name) === 0 &&
+                strcasecmp((string) $route->getModule(), $module) === 0
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getModuleBaseNamespace(): string
+    {
+        return environment()->isTesting()
+            ? 'Quantum\\Tests\\_root\\modules'
+            : 'Modules';
+    }
 }

--- a/src/Lang/Factories/LangFactory.php
+++ b/src/Lang/Factories/LangFactory.php
@@ -126,7 +126,7 @@ class LangFactory
     {
         $segmentIndex = (int) config()->get('lang.url_segment');
 
-        if (!in_array(route_prefix(), [null, '', '0'], true) && $segmentIndex === 1) {
+        if (!in_array(request()->getRoutePrefix(), [null, '', '0'], true) && $segmentIndex === 1) {
             $segmentIndex++;
         }
 

--- a/src/Lang/Translator.php
+++ b/src/Lang/Translator.php
@@ -60,7 +60,7 @@ class Translator
             $loaded = true;
         }
 
-        $moduleDir = modules_dir() . DS . current_module() . DS . 'resources' . DS . 'lang' . DS . $this->lang;
+        $moduleDir = modules_dir() . DS . request()->getCurrentModule() . DS . 'resources' . DS . 'lang' . DS . $this->lang;
         $moduleFiles = fs()->glob($moduleDir . DS . '*.php');
 
         if (is_array($moduleFiles) && count($moduleFiles)) {

--- a/src/Loader/Setup.php
+++ b/src/Loader/Setup.php
@@ -43,7 +43,7 @@ class Setup
         $this->pathPrefix = $pathPrefix;
         $this->fileName = $fileName;
         $this->hierarchical = $hierarchical;
-        $this->module = $module ?: current_module();
+        $this->module = $module ?: request()->getCurrentModule();
         $this->exceptionMessage = $exceptionMessage ?: 'File `' . $pathPrefix . DS . $fileName . '` not found!';
     }
 

--- a/src/Middleware/MiddlewareManager.php
+++ b/src/Middleware/MiddlewareManager.php
@@ -21,6 +21,7 @@ use Quantum\App\Exceptions\BaseException;
 use Quantum\Router\MatchedRoute;
 use Quantum\Http\Response;
 use Quantum\Http\Request;
+use ReflectionException;
 
 /**
  * Class MiddlewareManager
@@ -50,7 +51,7 @@ class MiddlewareManager
     /**
      * Apply Middlewares
      * @return array{0: Request, 1: Response}
-     * @throws MiddlewareException|BaseException
+     * @throws MiddlewareException|BaseException|ReflectionException
      */
     public function applyMiddlewares(Request $request, Response $response): array
     {
@@ -70,11 +71,11 @@ class MiddlewareManager
 
     /**
      * Loads and gets the current middleware instance
-     * @throws MiddlewareException|BaseException
+     * @throws MiddlewareException|BaseException|ReflectionException
      */
     private function getMiddleware(Request $request, Response $response): QtMiddleware
     {
-        $middlewareClass = module_base_namespace() . '\\' . $this->module . '\\Middlewares\\' . current($this->middlewares);
+        $middlewareClass = request()->getModuleBaseNamespace() . '\\' . $this->module . '\\Middlewares\\' . current($this->middlewares);
 
         if (!class_exists($middlewareClass)) {
             throw MiddlewareException::middlewareNotFound($middlewareClass);

--- a/src/Module/ModuleManager.php
+++ b/src/Module/ModuleManager.php
@@ -181,6 +181,9 @@ class ModuleManager
         return $copiedFiles;
     }
 
+    /**
+     * @throws DiException|ReflectionException
+     */
     private function processTemplates(string $srcPath, string &$dstPath): void
     {
         $dstPath = str_replace('.php.tpl', '.php', $dstPath);
@@ -194,10 +197,13 @@ class ModuleManager
         $this->fs->put($dstPath, $processedContent);
     }
 
+    /**
+     * @throws DiException|ReflectionException
+     */
     private function replacePlaceholders(string $content): string
     {
         $placeholders = [
-            '{{MODULE_NAMESPACE}}' => module_base_namespace() . '\\' . $this->getModuleName(),
+            '{{MODULE_NAMESPACE}}' => request()->getModuleBaseNamespace() . '\\' . $this->getModuleName(),
             '{{MODULE_NAME}}' => $this->getModuleName(),
         ];
 

--- a/src/Paginator/Traits/PaginatorTrait.php
+++ b/src/Paginator/Traits/PaginatorTrait.php
@@ -219,7 +219,7 @@ trait PaginatorTrait
      */
     protected function getUri(bool $withBaseUrl = false): string
     {
-        $routeUrl = preg_replace('/([?&](page|per_page)=\d+)/', '', route_uri() ?? '');
+        $routeUrl = preg_replace('/([?&](page|per_page)=\d+)/', '', request()->getUri() ?? '');
         $routeUrl = preg_replace('/&/', '?', $routeUrl ?? '', 1);
         $url = $routeUrl;
 

--- a/src/Renderer/Adapters/HtmlAdapter.php
+++ b/src/Renderer/Adapters/HtmlAdapter.php
@@ -83,7 +83,7 @@ class HtmlAdapter implements TemplateRendererInterface
      */
     private function getViewFilePath(string $view): string
     {
-        $moduleViewPath = modules_dir() . DS . current_module() . DS . 'Views' . DS . $view . '.php';
+        $moduleViewPath = modules_dir() . DS . request()->getCurrentModule() . DS . 'Views' . DS . $view . '.php';
         $sharedViewPath = base_dir() . DS . 'shared' . DS . 'views' . DS . $view . '.php';
 
         return $this->fs->exists($moduleViewPath) ? $moduleViewPath : $sharedViewPath;

--- a/src/Renderer/Adapters/TwigAdapter.php
+++ b/src/Renderer/Adapters/TwigAdapter.php
@@ -76,7 +76,7 @@ class TwigAdapter implements TemplateRendererInterface
      */
     private function getLoader(string $view): FilesystemLoader
     {
-        $moduleViewPath = modules_dir() . DS . current_module() . DS . 'Views' . DS . $view . '.php';
+        $moduleViewPath = modules_dir() . DS . request()->getCurrentModule() . DS . 'Views' . DS . $view . '.php';
         $sharedViewPath = base_dir() . DS . 'shared' . DS . 'views' . DS . $view . '.php';
 
         if ($this->fs->exists($moduleViewPath)) {

--- a/src/ResourceCache/ViewCache.php
+++ b/src/ResourceCache/ViewCache.php
@@ -183,7 +183,7 @@ class ViewCache
 
         $viewCacheDir = base_dir() . DS . $configCacheDir . DS . 'views';
 
-        if ($module = current_module()) {
+        if ($module = request()->getCurrentModule()) {
             $viewCacheDir = base_dir() . DS . $configCacheDir . DS . 'views' . DS . strtolower($module);
         }
 

--- a/src/Router/Helpers/router.php
+++ b/src/Router/Helpers/router.php
@@ -13,7 +13,6 @@
  */
 
 use Quantum\Di\Exceptions\DiException;
-use Quantum\Router\RouteCollection;
 use Quantum\Router\Route;
 use Quantum\Http\Request;
 use Quantum\Di\Di;
@@ -25,9 +24,7 @@ use Quantum\Di\Di;
  */
 function current_middlewares(): ?array
 {
-    $matchedRoute = request()->getMatchedRoute();
-
-    return $matchedRoute ? $matchedRoute->getRoute()->getMiddlewares() : null;
+    return request()->getCurrentMiddlewares();
 }
 
 /**
@@ -41,9 +38,7 @@ function current_module(): ?string
         return null;
     }
 
-    $matchedRoute = request()->getMatchedRoute();
-
-    return $matchedRoute ? $matchedRoute->getRoute()->getModule() : null;
+    return request()->getCurrentModule();
 }
 
 /**
@@ -53,9 +48,7 @@ function current_module(): ?string
  */
 function current_controller(): ?string
 {
-    $matchedRoute = request()->getMatchedRoute();
-
-    return $matchedRoute ? $matchedRoute->getRoute()->getController() : null;
+    return request()->getCurrentController();
 }
 
 /**
@@ -65,9 +58,7 @@ function current_controller(): ?string
  */
 function current_action(): ?string
 {
-    $matchedRoute = request()->getMatchedRoute();
-
-    return $matchedRoute ? $matchedRoute->getRoute()->getAction() : null;
+    return request()->getCurrentAction();
 }
 
 /**
@@ -77,9 +68,7 @@ function current_action(): ?string
  */
 function route_callback(): ?Closure
 {
-    $matchedRoute = request()->getMatchedRoute();
-
-    return $matchedRoute ? $matchedRoute->getRoute()->getClosure() : null;
+    return request()->getRouteCallback();
 }
 
 /**
@@ -89,9 +78,7 @@ function route_callback(): ?Closure
  */
 function current_route(): ?string
 {
-    $matchedRoute = request()->getMatchedRoute();
-
-    return $matchedRoute ? $matchedRoute->getRoute()->getPattern() : null;
+    return request()->getCurrentRoutePattern();
 }
 
 /**
@@ -101,9 +88,7 @@ function current_route(): ?string
  */
 function route_pattern(): string
 {
-    $matchedRoute = request()->getMatchedRoute();
-
-    return $matchedRoute ? ($matchedRoute->getRoute()->getCompiledPattern() ?? '') : '';
+    return request()->getCompiledRoutePattern();
 }
 
 /**
@@ -113,9 +98,7 @@ function route_pattern(): string
  */
 function route_params(): array
 {
-    $matchedRoute = request()->getMatchedRoute();
-
-    return $matchedRoute ? $matchedRoute->getParams() : [];
+    return request()->getRouteParams();
 }
 
 /**
@@ -126,8 +109,7 @@ function route_params(): array
  */
 function route_param(string $name)
 {
-    $params = route_params();
-    return $params[$name] ?? null;
+    return request()->getRouteParam($name);
 }
 
 /**
@@ -157,9 +139,7 @@ function route_uri(): ?string
  */
 function route_cache_settings(): ?array
 {
-    $matchedRoute = request()->getMatchedRoute();
-
-    return $matchedRoute ? $matchedRoute->getRoute()->getCache() : null;
+    return request()->getRouteCacheSettings();
 }
 
 /**
@@ -168,9 +148,7 @@ function route_cache_settings(): ?array
  */
 function route_name(): ?string
 {
-    $matchedRoute = request()->getMatchedRoute();
-
-    return $matchedRoute ? $matchedRoute->getRoute()->getName() : null;
+    return request()->getRouteName();
 }
 
 /**
@@ -179,9 +157,7 @@ function route_name(): ?string
  */
 function route_prefix(): ?string
 {
-    $matchedRoute = request()->getMatchedRoute();
-
-    return $matchedRoute ? $matchedRoute->getRoute()->getPrefix() : null;
+    return request()->getRoutePrefix();
 }
 
 /**
@@ -190,23 +166,7 @@ function route_prefix(): ?string
  */
 function find_route_by_name(string $name, string $module): ?Route
 {
-    if (!Di::isRegistered(RouteCollection::class)) {
-        return null;
-    }
-
-    $collection = Di::get(RouteCollection::class);
-
-    foreach ($collection->all() as $route) {
-        if (
-            $route->getName() !== null &&
-            strcasecmp($route->getName(), $name) === 0 &&
-            strcasecmp((string) $route->getModule(), $module) === 0
-        ) {
-            return $route;
-        }
-    }
-
-    return null;
+    return request()->findRouteByName($name, $module);
 }
 
 /**
@@ -215,23 +175,7 @@ function find_route_by_name(string $name, string $module): ?Route
  */
 function route_group_exists(string $name, string $module): bool
 {
-    if (!Di::isRegistered(RouteCollection::class)) {
-        return false;
-    }
-
-    $collection = Di::get(RouteCollection::class);
-
-    foreach ($collection->all() as $route) {
-        if (
-            $route->getGroup() !== null &&
-            strcasecmp($route->getGroup(), $name) === 0 &&
-            strcasecmp((string) $route->getModule(), $module) === 0
-        ) {
-            return true;
-        }
-    }
-
-    return false;
+    return request()->routeGroupExists($name, $module);
 }
 
 /**
@@ -239,7 +183,5 @@ function route_group_exists(string $name, string $module): bool
  */
 function module_base_namespace(): string
 {
-    return environment()->isTesting()
-        ? 'Quantum\\Tests\\_root\\modules'
-        : 'Modules';
+    return request()->getModuleBaseNamespace();
 }

--- a/src/Router/Helpers/router.php
+++ b/src/Router/Helpers/router.php
@@ -29,7 +29,6 @@ function current_middlewares(): ?array
 
 /**
  * Gets current route module
- * @return string|null
  * @throws DiException|ReflectionException
  */
 function current_module(): ?string
@@ -43,7 +42,6 @@ function current_module(): ?string
 
 /**
  * Gets current route controller
- * @return string|null
  * @throws DiException|ReflectionException
  */
 function current_controller(): ?string
@@ -53,7 +51,6 @@ function current_controller(): ?string
 
 /**
  * Gets current route action
- * @return string|null
  * @throws DiException|ReflectionException
  */
 function current_action(): ?string
@@ -63,7 +60,6 @@ function current_action(): ?string
 
 /**
  * Gets current route callback
- * @return Closure|null
  * @throws DiException|ReflectionException
  */
 function route_callback(): ?Closure
@@ -82,11 +78,10 @@ function current_route(): ?string
 }
 
 /**
- * Gets current route complied pattern
- * @return string
+ * Gets current route compiled pattern
  * @throws DiException|ReflectionException
  */
-function route_pattern(): string
+function route_pattern(): ?string
 {
     return request()->getCompiledRoutePattern();
 }
@@ -180,6 +175,7 @@ function route_group_exists(string $name, string $module): bool
 
 /**
  * Gets the module base namespace depending on env
+ * @throws DiException|ReflectionException
  */
 function module_base_namespace(): string
 {

--- a/src/Router/RouteBuilder.php
+++ b/src/Router/RouteBuilder.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 namespace Quantum\Router;
 
 use Quantum\Router\Exceptions\RouteException;
+use Quantum\Di\Exceptions\DiException;
+use ReflectionException;
 use Closure;
 
 /**
@@ -94,7 +96,7 @@ final class RouteBuilder
      * Define a route with multiple HTTP methods.
      * @param callable|string $handler
      * @param string|null $action
-     * @throws RouteException
+     * @throws RouteException|DiException|ReflectionException
      */
     public function add(string $path, string $methods, $handler, string $action = null): self
     {
@@ -110,7 +112,7 @@ final class RouteBuilder
      * Define a GET route.
      * @param callable|string $handler
      * @param string|null $action
-     * @throws RouteException
+     * @throws RouteException|DiException|ReflectionException
      */
     public function get(string $path, $handler, string $action = null): self
     {
@@ -121,7 +123,7 @@ final class RouteBuilder
      * Define a POST route.
      * @param callable|string $handler
      * @param string|null $action
-     * @throws RouteException
+     * @throws RouteException|DiException|ReflectionException
      */
     public function post(string $path, $handler, string $action = null): self
     {
@@ -132,7 +134,7 @@ final class RouteBuilder
      * Define a PUT route.
      * @param callable|string $handler
      * @param string|null $action
-     * @throws RouteException
+     * @throws RouteException|DiException|ReflectionException
      */
     public function put(string $path, $handler, string $action = null): self
     {
@@ -142,8 +144,7 @@ final class RouteBuilder
     /**
      * Define a DELETE route.
      * @param callable|string $handler
-     * @param string|null $action
-     * @throws RouteException
+     * @throws RouteException|DiException|ReflectionException
      */
     public function delete(string $path, $handler, string $action = null): self
     {
@@ -280,7 +281,7 @@ final class RouteBuilder
      * Create and register a Route instance.
      * @param array<string> $methods
      * @param callable|string $handler
-     * @throws RouteException
+     * @throws RouteException|DiException|ReflectionException
      */
     private function addRoute(
         array $methods,
@@ -313,7 +314,7 @@ final class RouteBuilder
                 }
 
                 $handler =
-                    module_base_namespace()
+                    request()->getModuleBaseNamespace()
                     . '\\'
                     . $this->currentModule
                     . '\\Controllers\\'

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -162,14 +162,7 @@ class View
     /**
      * Renders the view.
      * @param array<string, mixed> $params
-     * @throws AssetException
-     * @throws BaseException
-     * @throws ConfigException
-     * @throws DatabaseException
-     * @throws DiException
-     * @throws ReflectionException
-     * @throws SessionException
-     * @throws ViewException
+     * @throws ViewException|AssetException|SessionException|DatabaseException|ConfigException|BaseException|DiException|ReflectionException
      */
     public function render(string $viewFile, array $params = []): ?string
     {
@@ -196,7 +189,7 @@ class View
         $layoutContent = $this->renderFile($layoutFile);
 
         if ($this->viewCache->isEnabled()) {
-            $uri = route_uri();
+            $uri = request()->getUri();
             if ($uri !== null) {
                 $layoutContent = $this->viewCache
                     ->set($uri, $layoutContent)
@@ -289,7 +282,7 @@ class View
     {
         $routesCell = $this->debugger->getStoreCell(Debugger::ROUTES);
         $currentData = current($routesCell)[LogLevel::INFO] ?? [];
-        $additionalData = ['View' => current_module() . '/Views/' . $viewFile];
+        $additionalData = ['View' => request()->getCurrentModule() . '/Views/' . $viewFile];
         $mergedData = array_merge($currentData, $additionalData);
         $this->debugger->clearStoreCell(Debugger::ROUTES);
         $this->debugger->addToStoreCell(Debugger::ROUTES, LogLevel::INFO, $mergedData);

--- a/tests/Unit/Http/RequestTest.php
+++ b/tests/Unit/Http/RequestTest.php
@@ -92,6 +92,12 @@ class RequestTest extends AppTestCase
         $this->assertSame('api', request()->getRoutePrefix());
     }
 
+    public function testCompiledRoutePatternReturnsNullWhenNoRouteMatched(): void
+    {
+        request()->setMatchedRoute(null);
+        $this->assertNull(request()->getCompiledRoutePattern());
+    }
+
     public function testRouteCollectionProxyMethods(): void
     {
         $route = new Route(['GET'], 'dashboard', 'DashboardController', 'index');

--- a/tests/Unit/Http/RequestTest.php
+++ b/tests/Unit/Http/RequestTest.php
@@ -2,7 +2,11 @@
 
 namespace Quantum\Tests\Unit\Http;
 
+use Quantum\Router\RouteCollection;
 use Quantum\Tests\Unit\AppTestCase;
+use Quantum\Router\MatchedRoute;
+use Quantum\Router\Route;
+use Quantum\Di\Di;
 
 class RequestTest extends AppTestCase
 {
@@ -59,5 +63,51 @@ class RequestTest extends AppTestCase
 
         $this->assertNotNull($request->getCsrfToken());
 
+    }
+
+    public function testRouteMetadataProxyMethods(): void
+    {
+        $route = new Route(['GET'], 'post/[uuid=:any]', 'PostController', 'show');
+        $route
+            ->module('Web')
+            ->prefix('api')
+            ->group('content')
+            ->name('post.show')
+            ->addMiddlewares(['Auth'])
+            ->cache(true, 60)
+            ->setCompiledPattern('compiled-pattern');
+
+        request()->setMatchedRoute(new MatchedRoute($route, ['uuid' => 'abc-123']));
+
+        $this->assertSame(['Auth'], request()->getCurrentMiddlewares());
+        $this->assertSame('Web', request()->getCurrentModule());
+        $this->assertSame('PostController', request()->getCurrentController());
+        $this->assertSame('show', request()->getCurrentAction());
+        $this->assertSame('post/[uuid=:any]', request()->getCurrentRoutePattern());
+        $this->assertSame('compiled-pattern', request()->getCompiledRoutePattern());
+        $this->assertSame(['uuid' => 'abc-123'], request()->getRouteParams());
+        $this->assertSame('abc-123', request()->getRouteParam('uuid'));
+        $this->assertSame(['enabled' => true, 'ttl' => 60], request()->getRouteCacheSettings());
+        $this->assertSame('post.show', request()->getRouteName());
+        $this->assertSame('api', request()->getRoutePrefix());
+    }
+
+    public function testRouteCollectionProxyMethods(): void
+    {
+        $route = new Route(['GET'], 'dashboard', 'DashboardController', 'index');
+        $route->name('dashboard')->group('auth')->module('web');
+
+        $collection = Di::isRegistered(RouteCollection::class)
+            ? Di::get(RouteCollection::class)
+            : new RouteCollection();
+        $collection->add($route);
+
+        if (!Di::isRegistered(RouteCollection::class)) {
+            Di::set(RouteCollection::class, $collection);
+        }
+
+        $this->assertInstanceOf(Route::class, request()->findRouteByName('dashboard', 'web'));
+        $this->assertTrue(request()->routeGroupExists('auth', 'web'));
+        $this->assertFalse(request()->routeGroupExists('guest', 'web'));
     }
 }

--- a/tests/Unit/Router/Helpers/RouteHelpersTest.php
+++ b/tests/Unit/Router/Helpers/RouteHelpersTest.php
@@ -26,7 +26,7 @@ class RouteHelpersTest extends AppTestCase
         $this->assertNull(current_action());
         $this->assertNull(route_callback());
         $this->assertNull(current_route());
-        $this->assertSame('', route_pattern());
+        $this->assertNull(route_pattern());
         $this->assertSame([], route_params());
         $this->assertNull(route_param('id'));
         $this->assertNull(route_cache_settings());


### PR DESCRIPTION
Closes #462 

Move router metadata access behind Request proxy methods, migrate core internal usages from router helpers to request()-> methods, and remove dead helper functions while keeping public helper wrappers for DX compatibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized request routing/context accessors for more consistent route/module/controller/action metadata across the app.
* **Behavioral**
  * View caching and pagination URL generation now use the current request URI (may affect cached views and page links).
  * Localization now derives language and translation resolution from the current request/module context.
* **Tests**
  * Added unit tests covering request route metadata and route-lookup helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->