### PR TITLE
[#470] Enforce response-returning route dispatch

### DIFF
--- a/src/Http/Traits/Response/Body.php
+++ b/src/Http/Traits/Response/Body.php
@@ -66,9 +66,10 @@ trait Body
      * Sets new key/value pair into response
      * @param mixed $value
      */
-    public function set(string $key, $value): void
+    public function set(string $key, $value): self
     {
         $this->__response[$key] = $value;
+        return $this;
     }
 
     /**
@@ -94,7 +95,7 @@ trait Body
      * Prepares the JSON response
      * @param array<string, mixed>|null $data
      */
-    public function json(?array $data = null, ?int $code = null): void
+    public function json(?array $data = null, ?int $code = null): self
     {
         $this->setContentType(ContentType::JSON);
 
@@ -105,13 +106,15 @@ trait Body
         if ($data) {
             $this->__response = array_merge($this->__response, $data);
         }
+
+        return $this;
     }
 
     /**
      * Prepares the JSONP response
      * @param array<string, mixed>|null $data
      */
-    public function jsonp(string $callback, ?array $data = null, ?int $code = null): void
+    public function jsonp(string $callback, ?array $data = null, ?int $code = null): self
     {
         $this->setContentType(ContentType::JSONP);
 
@@ -124,6 +127,8 @@ trait Body
         if ($data) {
             $this->__response = array_merge($this->__response, $data);
         }
+
+        return $this;
     }
 
     /**
@@ -140,7 +145,7 @@ trait Body
      * @param array<string, mixed>|null $data
      * @param string $root
      */
-    public function xml(?array $data = null, $root = '<data></data>', ?int $code = null): void
+    public function xml(?array $data = null, $root = '<data></data>', ?int $code = null): self
     {
         $this->setContentType(ContentType::XML);
 
@@ -153,12 +158,14 @@ trait Body
         if ($data) {
             $this->__response = array_merge($this->__response, $data);
         }
+
+        return $this;
     }
 
     /**
      * Prepares the HTML content
      */
-    public function html(string $html, ?int $code = null): void
+    public function html(string $html, ?int $code = null): self
     {
         $this->setContentType(ContentType::HTML);
 
@@ -167,6 +174,8 @@ trait Body
         }
 
         $this->__response[ReservedKeys::RENDERED_VIEW] = $html;
+
+        return $this;
     }
 
     /**

--- a/src/Http/Traits/Response/Header.php
+++ b/src/Http/Traits/Response/Header.php
@@ -50,9 +50,10 @@ trait Header
     /**
      * Sets the response header
      */
-    public function setHeader(string $key, string $value): void
+    public function setHeader(string $key, string $value): self
     {
         $this->__headers[$key] = $value;
+        return $this;
     }
 
     /**
@@ -77,9 +78,9 @@ trait Header
     /**
      * Sets the content type
      */
-    public function setContentType(string $contentType): void
+    public function setContentType(string $contentType): self
     {
-        $this->setHeader('Content-Type', $contentType);
+        return $this->setHeader('Content-Type', $contentType);
     }
 
     /**

--- a/src/Http/Traits/Response/Status.php
+++ b/src/Http/Traits/Response/Status.php
@@ -118,13 +118,15 @@ trait Status
     /**
      * Sets the status code
      */
-    public function setStatusCode(int $code): void
+    public function setStatusCode(int $code): self
     {
         if (!isset($this->texts[$code])) {
             throw new InvalidArgumentException(sprintf('The HTTP status code "%s" is not valid.', $code));
         }
 
         $this->__statusCode = $code;
+
+        return $this;
     }
 
     /**

--- a/src/Router/Enums/ExceptionMessages.php
+++ b/src/Router/Enums/ExceptionMessages.php
@@ -46,6 +46,8 @@ final class ExceptionMessages extends BaseExceptionMessages
 
     public const ACTION_NOT_FOUND_ON_CONTROLLER = 'Action `{%1}` not found on controller `{%2}`';
 
+    public const INVALID_HANDLER_RESPONSE = 'Route handler `{%1}` must return `{%2}`';
+
     public const ROUTE_NOT_CLOSURE = 'Route is not a closure';
 
     public const NAME_BEFORE_ROUTE_DEFINITION = 'Names can not be set before route definition';

--- a/src/Router/Exceptions/RouteException.php
+++ b/src/Router/Exceptions/RouteException.php
@@ -116,6 +116,17 @@ class RouteException extends BaseException
         );
     }
 
+    public static function invalidHandlerResponse(string $handler, string $expectedType): self
+    {
+        return new self(
+            _message(
+                ExceptionMessages::INVALID_HANDLER_RESPONSE,
+                [$handler, $expectedType]
+            ),
+            E_ERROR
+        );
+    }
+
     public static function notClosure(): self
     {
         return new self(

--- a/src/Router/RouteDispatcher.php
+++ b/src/Router/RouteDispatcher.php
@@ -19,10 +19,12 @@ namespace Quantum\Router;
 use Quantum\Router\Exceptions\RouteException;
 use Quantum\Csrf\Exceptions\CsrfException;
 use Quantum\Di\Exceptions\DiException;
+use Quantum\Http\Response;
 use Quantum\Http\Request;
 use ReflectionException;
 use Quantum\Csrf\Csrf;
 use Quantum\Di\Di;
+use Closure;
 
 /**
  * Class RouteDispatcher
@@ -34,7 +36,7 @@ final class RouteDispatcher
      * Dispatch a matched route.
      * @throws ReflectionException|CsrfException|DiException|RouteException
      */
-    public function dispatch(MatchedRoute $matched, Request $request): void
+    public function dispatch(MatchedRoute $matched, Request $request): Response
     {
         $route = $matched->getRoute();
         $params = $matched->getParams();
@@ -46,8 +48,10 @@ final class RouteDispatcher
                 throw RouteException::closureHandlerMissing();
             }
 
-            $this->invoke($closure, $params);
-            return;
+            return $this->requireResponse(
+                $this->invoke($closure, $params),
+                'closure route'
+            );
         }
 
         $callable = $this->resolveControllerCallable($route);
@@ -57,10 +61,14 @@ final class RouteDispatcher
 
         $this->callHook($controller, '__before', $params);
 
-        /** @phpstan-ignore argument.type */
-        $this->invoke($callable, $params);
+        $response = $this->requireResponse(
+            $this->invoke($callable, $params),
+            $route->getController() . '::' . $route->getAction()
+        );
 
         $this->callHook($controller, '__after', $params);
+
+        return $response;
     }
 
     /**
@@ -88,15 +96,30 @@ final class RouteDispatcher
 
     /**
      * Invoke a callable with parameters resolved via DI autowiring.
+     * @param callable|array{0: object, 1: string} $callable
      * @param array<string, mixed> $params
-     * @throws DiException|ReflectionException
+     * @return mixed
      */
-    private function invoke(callable $callable, array $params): void
+    private function invoke($callable, array $params)
     {
-        call_user_func_array(
-            $callable,
-            Di::autowire($callable, $params)
-        );
+        /** @var callable $callable */
+        $closure = Closure::fromCallable($callable);
+
+        return $closure(...Di::autowire($closure, $params));
+    }
+
+    /**
+     * Enforce a Response return contract for route handlers.
+     * @param mixed $result
+     * @throws RouteException
+     */
+    private function requireResponse($result, string $handler): Response
+    {
+        if (!$result instanceof Response) {
+            throw RouteException::invalidHandlerResponse($handler, Response::class);
+        }
+
+        return $result;
     }
 
     /**
@@ -107,7 +130,6 @@ final class RouteDispatcher
     private function callHook(object $controller, string $hook, array $params): void
     {
         if (method_exists($controller, $hook)) {
-            /** @phpstan-ignore argument.type */
             $this->invoke([$controller, $hook], $params);
         }
     }

--- a/tests/Unit/Http/Traits/Response/HttpResponseBodyTest.php
+++ b/tests/Unit/Http/Traits/Response/HttpResponseBodyTest.php
@@ -24,7 +24,9 @@ class HttpResponseBodyTest extends AppTestCase
 
         $this->assertFalse($response->has('name'));
 
-        $response->set('name', 'John');
+        $returned = $response->set('name', 'John');
+
+        $this->assertSame($response, $returned);
 
         $this->assertTrue($response->has('name'));
 
@@ -49,7 +51,7 @@ class HttpResponseBodyTest extends AppTestCase
 
         $response->set('lastname', 'Doe');
 
-        $response->json();
+        $this->assertSame($response, $response->json());
 
         $this->assertEquals('{"firstname":"John","lastname":"Doe"}', $response->getContent());
 
@@ -75,7 +77,7 @@ class HttpResponseBodyTest extends AppTestCase
 
         $response->set('lastname', 'Doe');
 
-        $response->jsonp('myfunc');
+        $this->assertSame($response, $response->jsonp('myfunc'));
 
         $this->assertEquals('myfunc({"firstname":"John","lastname":"Doe"})', $response->getContent());
     }
@@ -88,7 +90,7 @@ class HttpResponseBodyTest extends AppTestCase
 
         $response->set('lastname', 'Doe');
 
-        $response->xml();
+        $this->assertSame($response, $response->xml());
 
         $xml = "<?xml version=\"1.0\"?>\n" .
             "<data>\n" .
@@ -196,7 +198,7 @@ class HttpResponseBodyTest extends AppTestCase
     {
         $response = response();
 
-        $response->html('<div>John Doe</div>');
+        $this->assertSame($response, $response->html('<div>John Doe</div>'));
 
         $this->assertEquals('<div>John Doe</div>', $response->getContent());
 

--- a/tests/Unit/Http/Traits/Response/HttpResponseHeaderTest.php
+++ b/tests/Unit/Http/Traits/Response/HttpResponseHeaderTest.php
@@ -20,7 +20,9 @@ class HttpResponseHeaderTest extends AppTestCase
 
         $this->assertFalse($response->hasHeader('X-Frame-Options'));
 
-        $response->setHeader('X-Frame-Options', 'deny');
+        $returned = $response->setHeader('X-Frame-Options', 'deny');
+
+        $this->assertSame($response, $returned);
 
         $this->assertTrue($response->hasHeader('X-Frame-Options'));
 

--- a/tests/Unit/Http/Traits/Response/HttpResponseStatusTest.php
+++ b/tests/Unit/Http/Traits/Response/HttpResponseStatusTest.php
@@ -17,7 +17,9 @@ class HttpResponseStatusTest extends AppTestCase
 
         $this->assertEquals(200, $response->getStatusCode());
 
-        $response->setStatusCode(301);
+        $returned = $response->setStatusCode(301);
+
+        $this->assertSame($response, $returned);
 
         $this->assertEquals(301, $response->getStatusCode());
 

--- a/tests/Unit/Router/RouteDispatcherTest.php
+++ b/tests/Unit/Router/RouteDispatcherTest.php
@@ -11,6 +11,7 @@ use Quantum\Http\Response;
 use Quantum\Router\Route;
 use Quantum\Http\Request;
 use Quantum\Csrf\Csrf;
+use Quantum\Di\Di;
 use Mockery;
 
 class RouteDispatcherTest extends AppTestCase
@@ -23,12 +24,15 @@ class RouteDispatcherTest extends AppTestCase
 
     public function testDispatchExecutesClosureRoute(): void
     {
-        $called = false;
-        $receivedParam = null;
+        $expectedResponse = response();
 
-        $closure = function (string $id) use (&$called, &$receivedParam): void {
-            $called = true;
-            $receivedParam = $id;
+        $closure = function (string $id, Response $response) use ($expectedResponse): Response {
+            $this->assertSame('123', $id);
+            $this->assertSame($expectedResponse, $response);
+
+            return $response->json([
+                'id' => $id,
+            ]);
         };
 
         $route = new Route(['GET'], '/test', null, null, $closure);
@@ -41,12 +45,10 @@ class RouteDispatcherTest extends AppTestCase
         $dispatcher = new RouteDispatcher();
 
         $request = Mockery::mock(Request::class);
-        Mockery::mock(Response::class);
+        $response = $dispatcher->dispatch($matched, $request);
 
-        $dispatcher->dispatch($matched, $request);
-
-        $this->assertTrue($called);
-        $this->assertSame('123', $receivedParam);
+        $this->assertSame($expectedResponse, $response);
+        $this->assertSame('{"id":"123"}', $response->getContent());
     }
 
     public function testDispatchThrowsWhenClosureRouteHasNoClosure(): void
@@ -70,9 +72,13 @@ class RouteDispatcherTest extends AppTestCase
         $controllerClass = new class () {
             public static ?string $received = null;
 
-            public function post(string $uuid): void
+            public function post(string $uuid, Response $response): Response
             {
                 self::$received = $uuid;
+
+                return $response->json([
+                    'uuid' => $uuid,
+                ]);
             }
         };
 
@@ -83,15 +89,15 @@ class RouteDispatcherTest extends AppTestCase
         $dispatcher = new RouteDispatcher();
 
         $request = Mockery::mock(Request::class);
-        Mockery::mock(Response::class);
 
-        $dispatcher->dispatch($matched, $request);
+        $response = $dispatcher->dispatch($matched, $request);
 
         $this->assertSame(
             'abc-123',
             $controllerClass::$received,
             'Controller action did not receive matched parameters'
         );
+        $this->assertSame('{"uuid":"abc-123"}', $response->getContent());
     }
 
     public function testDispatchCallsControllerHooksInCorrectOrder(): void
@@ -104,9 +110,13 @@ class RouteDispatcherTest extends AppTestCase
                 self::$calls[] = 'before:' . $uuid;
             }
 
-            public function post(string $uuid): void
+            public function post(string $uuid, Response $response): Response
             {
                 self::$calls[] = 'action:' . $uuid;
+
+                return $response->json([
+                    'uuid' => $uuid,
+                ]);
             }
 
             public function __after(string $uuid): void
@@ -124,9 +134,7 @@ class RouteDispatcherTest extends AppTestCase
         $request = Mockery::mock(Request::class);
         $request->shouldReceive('getMethod')->andReturn('POST');
 
-        Mockery::mock(Response::class);
-
-        $dispatcher->dispatch($matched, $request);
+        $response = $dispatcher->dispatch($matched, $request);
 
         $this->assertSame(
             [
@@ -137,6 +145,42 @@ class RouteDispatcherTest extends AppTestCase
             $controllerClass::$calls,
             'Controller hooks were not executed in the correct order'
         );
+        $this->assertSame('{"uuid":"abc"}', $response->getContent());
+    }
+
+    public function testDispatchThrowsWhenClosureRouteDoesNotReturnResponse(): void
+    {
+        $this->expectException(RouteException::class);
+
+        $route = new Route(['GET'], '/broken', null, null, function (): string {
+            return 'invalid';
+        });
+
+        $matched = new MatchedRoute($route, []);
+
+        $dispatcher = new RouteDispatcher();
+
+        $request = Mockery::mock(Request::class);
+
+        $dispatcher->dispatch($matched, $request);
+    }
+
+    public function testDispatchThrowsWhenControllerActionDoesNotReturnResponse(): void
+    {
+        $this->expectException(RouteException::class);
+
+        $controllerClass = new class () {
+            public function post(): void
+            {
+            }
+        };
+
+        $route = new Route(['GET'], '/invalid', get_class($controllerClass), 'post');
+        $matched = new MatchedRoute($route, []);
+        $dispatcher = new RouteDispatcher();
+        $request = Mockery::mock(Request::class);
+
+        $dispatcher->dispatch($matched, $request);
     }
 
     public function testDispatchThrowsWhenControllerActionDoesNotExist(): void
@@ -182,7 +226,12 @@ class RouteDispatcherTest extends AppTestCase
             ->with(Csrf::TOKEN_KEY)
             ->andReturn(false);
 
-        Mockery::mock(Response::class);
+        $csrf = Mockery::mock(Csrf::class);
+        $csrf->shouldReceive('checkToken')
+            ->with($request)
+            ->andThrow(new CsrfException('Missing CSRF token'));
+
+        Di::set(Csrf::class, $csrf);
 
         $dispatcher = new RouteDispatcher();
 

--- a/tests/_root/modules/Test/Controllers/TestController.php
+++ b/tests/_root/modules/Test/Controllers/TestController.php
@@ -2,10 +2,12 @@
 
 namespace Quantum\Tests\_root\modules\Test\Controllers;
 
+use Quantum\Http\Response;
+
 class TestController
 {
-    public function tests(): void
+    public function tests(Response $response): Response
     {
-        //
+        return $response->html('');
     }
 }


### PR DESCRIPTION
Closes #470 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Response methods now support fluent method chaining, allowing cleaner and more concise code when building responses.

* **Bug Fixes**
  * Route handlers now enforce returning a Response object, providing clearer error messages when invalid handler responses are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->