### PR TITLE
496 remove response param in templates

### DIFF
--- a/src/Module/Templates/DefaultApi/src/Controllers/MainController.php.tpl
+++ b/src/Module/Templates/DefaultApi/src/Controllers/MainController.php.tpl
@@ -34,7 +34,6 @@ class MainController
 
     /**
      * CSRF verification
-     * @var bool
      */
     public bool $csrfVerification = false;
 

--- a/src/Module/Templates/DefaultApi/src/Controllers/MainController.php.tpl
+++ b/src/Module/Templates/DefaultApi/src/Controllers/MainController.php.tpl
@@ -37,14 +37,13 @@ class MainController
      * @var bool
      */
     public bool $csrfVerification = false;
-    
+
     /**
      * Action - success response
-     * @param Response $response
      */
-    public function index(Response $response): Response
+    public function index(): Response
     {
-        return $response->json([
+        return response()->json([
             'status' => 'success',
             'message' => '{{MODULE_NAME}} module.'
         ]);

--- a/src/Module/Templates/DefaultApi/src/Controllers/OpenApi/OpenApiMainController.php.tpl
+++ b/src/Module/Templates/DefaultApi/src/Controllers/OpenApi/OpenApiMainController.php.tpl
@@ -22,7 +22,7 @@ use Quantum\Http\Response;
  */
 abstract class OpenApiMainController extends OpenApiController
 {
-   
+
     /**
      * @OA\Get(
      *     path="/{{MODULE_NAME}}",
@@ -40,6 +40,6 @@ abstract class OpenApiMainController extends OpenApiController
      *     )
      * )
      */
-    abstract public function index(Response $response);
+    abstract public function index();
 
 }

--- a/src/Module/Templates/DefaultWeb/src/Controllers/MainController.php.tpl
+++ b/src/Module/Templates/DefaultWeb/src/Controllers/MainController.php.tpl
@@ -32,7 +32,6 @@ class MainController
 
     /**
      * Works before an action
-     * @param ViewFactory $view
      */
     public function __before(ViewFactory $view)
     {
@@ -44,7 +43,6 @@ class MainController
 
     /**
      * Action - display home page
-     * @param ViewFactory $view
      */
     public function index(ViewFactory $view): Response
     {

--- a/src/Module/Templates/DefaultWeb/src/Controllers/MainController.php.tpl
+++ b/src/Module/Templates/DefaultWeb/src/Controllers/MainController.php.tpl
@@ -50,6 +50,6 @@ class MainController
             'title' => config()->get('app.name'),
         ]);
 
-        return $response->html($view->render('index'));
+        return response()->html($view->render('index'));
     }
 }

--- a/src/Module/Templates/DefaultWeb/src/Controllers/MainController.php.tpl
+++ b/src/Module/Templates/DefaultWeb/src/Controllers/MainController.php.tpl
@@ -41,18 +41,17 @@ class MainController
             new Asset(Asset::CSS, '{{MODULE_NAME}}/css/custom.css')
         ]);
     }
-    
+
     /**
      * Action - display home page
-     * @param Response $response
      * @param ViewFactory $view
      */
-    public function index(Response $response, ViewFactory $view): Response
-    {   
+    public function index(ViewFactory $view): Response
+    {
         $view->setParams([
             'title' => config()->get('app.name'),
         ]);
-        
+
         return $response->html($view->render('index'));
     }
 }

--- a/src/Module/Templates/DemoApi/src/Controllers/AccountController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/AccountController.php.tpl
@@ -28,13 +28,8 @@ class AccountController extends BaseController
 {
     /**
      * Auth service
-     * @var AuthService
      */
     public AuthService $authService;
-
-    /**
-     * Works before an action
-     */
 
     public function __before()
     {
@@ -43,7 +38,6 @@ class AccountController extends BaseController
 
     /**
      * Action - update user info
-     * @param Request $request
      */
     public function update(Request $request): Response
     {
@@ -72,7 +66,6 @@ class AccountController extends BaseController
 
     /**
      * Action - update password
-     * @param Request $request
      */
     public function updatePassword(Request $request): Response
     {

--- a/src/Module/Templates/DemoApi/src/Controllers/AccountController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/AccountController.php.tpl
@@ -57,7 +57,7 @@ class AccountController extends BaseController
                 'message' => t('common.updated_successfully')
             ]);
         } catch (AuthException $e) {
-            return $response->json([
+            return response()->json([
                 'status' => self::STATUS_ERROR,
                 'message' => $e->getMessage()
             ]);
@@ -83,7 +83,7 @@ class AccountController extends BaseController
                 'message' => t('common.updated_successfully')
             ]);
         } catch (AuthException $e) {
-            return $response->json([
+            return response()->json([
                 'status' => self::STATUS_ERROR,
                 'message' => $e->getMessage()
             ]);

--- a/src/Module/Templates/DemoApi/src/Controllers/AccountController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/AccountController.php.tpl
@@ -31,7 +31,7 @@ class AccountController extends BaseController
      * @var AuthService
      */
     public AuthService $authService;
-    
+
     /**
      * Works before an action
      */
@@ -44,9 +44,8 @@ class AccountController extends BaseController
     /**
      * Action - update user info
      * @param Request $request
-     * @param Response $response
      */
-    public function update(Request $request, Response $response): Response
+    public function update(Request $request): Response
     {
         try {
             $firstname = $request->get('firstname');
@@ -59,7 +58,7 @@ class AccountController extends BaseController
 
             auth()->refreshUser(auth()->user()->uuid);
 
-            return $response->json([
+            return response()->json([
                 'status' => self::STATUS_SUCCESS,
                 'message' => t('common.updated_successfully')
             ]);
@@ -74,20 +73,19 @@ class AccountController extends BaseController
     /**
      * Action - update password
      * @param Request $request
-     * @param Response $response
      */
-    public function updatePassword(Request $request, Response $response): Response
+    public function updatePassword(Request $request): Response
     {
         try {
             $hasher = new Hasher();
-    
+
             $newPassword = $request->get('new_password');
-    
+
             $this->authService->update('uuid', auth()->user()->uuid, [
                 'password' => $hasher->hash($newPassword)
             ]);
 
-            return $response->json([
+            return response()->json([
                 'status' => self::STATUS_SUCCESS,
                 'message' => t('common.updated_successfully')
             ]);

--- a/src/Module/Templates/DemoApi/src/Controllers/AuthController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/AuthController.php.tpl
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.9
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Controllers;
@@ -27,11 +27,8 @@ use Quantum\Http\Request;
  */
 class AuthController extends BaseController
 {
-
     /**
      * Action - sign in
-     * @param Request $request
-     * @return Response
      */
     public function signin(Request $request): Response
     {
@@ -56,7 +53,6 @@ class AuthController extends BaseController
 
     /**
      * Action - me
-     * @return Response
      */
     public function me(): Response
     {
@@ -72,7 +68,6 @@ class AuthController extends BaseController
 
     /**
      * Action - sign out
-     * @return Response
      */
     public function signout(): Response
     {
@@ -90,8 +85,6 @@ class AuthController extends BaseController
 
     /**
      *  Action - sign up
-     * @param Request $request
-     * @return Response
      */
     public function signup(Request $request): Response
     {
@@ -107,8 +100,6 @@ class AuthController extends BaseController
 
     /**
      * Action - activate
-     * @param Request $request
-     * @return Response
      */
     public function activate(Request $request): Response
     {
@@ -122,8 +113,6 @@ class AuthController extends BaseController
 
     /**
      * Action - forget
-     * @param Request $request
-     * @return Response
      */
     public function forget(Request $request): Response
     {
@@ -137,8 +126,6 @@ class AuthController extends BaseController
 
     /**
      * Action - reset
-     * @param Request $request
-     * @return Response
      */
     public function reset(Request $request): Response
     {
@@ -151,8 +138,6 @@ class AuthController extends BaseController
 
     /**
      * Action - Verify OTP
-     * @param Request $request
-     * @return Response
      */
     public function verify(Request $request): Response
     {
@@ -172,7 +157,6 @@ class AuthController extends BaseController
 
     /**
      *  Action - Resend OTP
-     * @return Response
      */
     public function resend(): Response
     {

--- a/src/Module/Templates/DemoApi/src/Controllers/AuthController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/AuthController.php.tpl
@@ -31,11 +31,11 @@ class AuthController extends BaseController
     /**
      * Action - sign in
      * @param Request $request
-     * @param Response $response
      * @return Response
      */
-    public function signin(Request $request, Response $response): Response
+    public function signin(Request $request): Response
     {
+        $response = response();
         try {
             $code = auth()->signin($request->get('email'), $request->get('password'));
 
@@ -56,12 +56,11 @@ class AuthController extends BaseController
 
     /**
      * Action - me
-     * @param Response $response
      * @return Response
      */
-    public function me(Response $response): Response
+    public function me(): Response
     {
-        return $response->json([
+        return response()->json([
             'status' => self::STATUS_SUCCESS,
             'data' => [
                 'firstname' => auth()->user()->firstname,
@@ -73,13 +72,12 @@ class AuthController extends BaseController
 
     /**
      * Action - sign out
-     * @param Response $response
      * @return Response
      */
-    public function signout(Response $response): Response
+    public function signout(): Response
     {
         if (auth()->signout()) {
-            return $response->json([
+            return response()->json([
                 'status' => self::STATUS_SUCCESS
             ]);
         } else {
@@ -93,16 +91,15 @@ class AuthController extends BaseController
     /**
      *  Action - sign up
      * @param Request $request
-     * @param Response $response
      * @return Response
      */
-    public function signup(Request $request, Response $response): Response
+    public function signup(Request $request): Response
     {
         $userDto = UserDTO::fromRequest($request, Role::EDITOR, uuid_ordered());
 
         auth()->signup($userDto->toArray());
 
-        return $response->json([
+        return response()->json([
             'status' => self::STATUS_SUCCESS,
             'message' => t('common.successfully_signed_up')
         ]);
@@ -111,14 +108,13 @@ class AuthController extends BaseController
     /**
      * Action - activate
      * @param Request $request
-     * @param Response $response
      * @return Response
      */
-    public function activate(Request $request, Response $response): Response
+    public function activate(Request $request): Response
     {
         auth()->activate($request->get('activation_token'));
 
-        return $response->json([
+        return response()->json([
             'status' => self::STATUS_SUCCESS,
             'message' => t('common.account_activated')
         ]);
@@ -127,14 +123,13 @@ class AuthController extends BaseController
     /**
      * Action - forget
      * @param Request $request
-     * @param Response $response
      * @return Response
      */
-    public function forget(Request $request, Response $response): Response
+    public function forget(Request $request): Response
     {
         auth()->forget($request->get('email'));
 
-        return $response->json([
+        return response()->json([
             'status' => self::STATUS_SUCCESS,
             'message' => t('common.check_email')
         ]);
@@ -143,14 +138,13 @@ class AuthController extends BaseController
     /**
      * Action - reset
      * @param Request $request
-     * @param Response $response
      * @return Response
      */
-    public function reset(Request $request, Response $response): Response
+    public function reset(Request $request): Response
     {
         auth()->reset($request->get('reset_token'), $request->get('password'));
 
-        return $response->json([
+        return response()->json([
             'status' => self::STATUS_SUCCESS
         ]);
     }
@@ -158,15 +152,14 @@ class AuthController extends BaseController
     /**
      * Action - Verify OTP
      * @param Request $request
-     * @param Response $response
      * @return Response
      */
-    public function verify(Request $request, Response $response): Response
+    public function verify(Request $request): Response
     {
         try {
             auth()->verifyOtp((int)$request->get('otp'), $request->get('code'));
 
-            return $response->json([
+            return response()->json([
                 'status' => self::STATUS_SUCCESS
             ]);
         } catch (AuthException $e) {
@@ -179,13 +172,12 @@ class AuthController extends BaseController
 
     /**
      *  Action - Resend OTP
-     * @param Response $response
      * @return Response
      */
-    public function resend(Response $response): Response
+    public function resend(): Response
     {
         try {
-            return $response->json([
+            return response()->json([
                 'status' => self::STATUS_SUCCESS,
                 'code' => auth()->resendOtp(route_param('code'))
             ]);

--- a/src/Module/Templates/DemoApi/src/Controllers/AuthController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/AuthController.php.tpl
@@ -76,7 +76,7 @@ class AuthController extends BaseController
                 'status' => self::STATUS_SUCCESS
             ]);
         } else {
-            return $response->json([
+            return response()->json([
                 'status' => self::STATUS_ERROR,
                 'message' => t('validation.unauthorizedRequest')
             ], StatusCode::UNAUTHORIZED);
@@ -148,7 +148,7 @@ class AuthController extends BaseController
                 'status' => self::STATUS_SUCCESS
             ]);
         } catch (AuthException $e) {
-            return $response->json([
+            return response()->json([
                 'status' => self::STATUS_ERROR,
                 'message' => $e->getMessage()
             ], StatusCode::UNAUTHORIZED);
@@ -166,7 +166,7 @@ class AuthController extends BaseController
                 'code' => auth()->resendOtp(route_param('code'))
             ]);
         } catch (AuthException $e) {
-            return $response->json([
+            return response()->json([
                 'status' => self::STATUS_ERROR,
                 'message' => $e->getMessage()
             ], StatusCode::UNAUTHORIZED);

--- a/src/Module/Templates/DemoApi/src/Controllers/BaseController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/BaseController.php.tpl
@@ -33,7 +33,6 @@ abstract class BaseController
 
     /**
      * CSRF verification
-     * @var bool
      */
     public bool $csrfVerification = false;
 }

--- a/src/Module/Templates/DemoApi/src/Controllers/CommentController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/CommentController.php.tpl
@@ -25,10 +25,6 @@ use Quantum\Http\Request;
  */
 class CommentController extends BaseController
 {
-
-    /**
-     * @var CommentService
-     */
     public CommentService $commentService;
 
     public function __before()
@@ -38,9 +34,6 @@ class CommentController extends BaseController
 
     /**
      * Action - create comment
-     * @param Request $request
-     * @param string|null $lang
-     * @param string $uuid
      */
     public function create(Request $request,  ?string $lang, string $uuid): Response
     {
@@ -57,8 +50,6 @@ class CommentController extends BaseController
 
     /**
      * Action - delete comment
-     * @param string|null $lang
-     * @param string $uuid
      */
     public function delete(?string $lang, string $uuid): Response
     {

--- a/src/Module/Templates/DemoApi/src/Controllers/CommentController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/CommentController.php.tpl
@@ -39,17 +39,16 @@ class CommentController extends BaseController
     /**
      * Action - create comment
      * @param Request $request
-     * @param Response $response
      * @param string|null $lang
      * @param string $uuid
      */
-    public function create(Request $request, Response $response, ?string $lang, string $uuid): Response
+    public function create(Request $request,  ?string $lang, string $uuid): Response
     {
         $commentDto = CommentDTO::fromRequest($request, $uuid, auth()->user()->uuid);
 
         $comment = $this->commentService->addComment($commentDto);
 
-        return $response->json([
+        return response()->json([
             'status' => 'success',
             'message' => t('common.created_successfully'),
             'data' => $comment
@@ -58,15 +57,14 @@ class CommentController extends BaseController
 
     /**
      * Action - delete comment
-     * @param Response $response
      * @param string|null $lang
      * @param string $uuid
      */
-    public function delete(Response $response, ?string $lang, string $uuid): Response
+    public function delete(?string $lang, string $uuid): Response
     {
         $this->commentService->deleteComment($uuid);
 
-        return $response->json([
+        return response()->json([
             'status' => 'success',
             'message' => t('common.deleted_successfully'),
         ]);

--- a/src/Module/Templates/DemoApi/src/Controllers/CommentController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/CommentController.php.tpl
@@ -35,7 +35,7 @@ class CommentController extends BaseController
     /**
      * Action - create comment
      */
-    public function create(Request $request,  ?string $lang, string $uuid): Response
+    public function create(Request $request, ?string $lang, string $uuid): Response
     {
         $commentDto = CommentDTO::fromRequest($request, $uuid, auth()->user()->uuid);
 

--- a/src/Module/Templates/DemoApi/src/Controllers/OpenApi/OpenApiAuthController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/OpenApi/OpenApiAuthController.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Controllers/OpenApi/OpenApiAuthController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/OpenApi/OpenApiAuthController.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Controllers\OpenApi;
@@ -63,7 +63,6 @@ abstract class OpenApiAuthController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Request $request
      */
     abstract public function signin(Request $request);
 
@@ -182,7 +181,6 @@ abstract class OpenApiAuthController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Request $request
      */
     abstract public function signup(Request $request);
 
@@ -218,7 +216,6 @@ abstract class OpenApiAuthController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Request $request
      */
     abstract public function activate(Request $request);
 
@@ -257,7 +254,6 @@ abstract class OpenApiAuthController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Request $request
      */
     abstract public function forget(Request $request);
 
@@ -309,7 +305,6 @@ abstract class OpenApiAuthController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Request $request
      */
     abstract public function reset(Request $request);
 
@@ -348,7 +343,6 @@ abstract class OpenApiAuthController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Request $request
      */
     abstract public function verify(Request $request);
 

--- a/src/Module/Templates/DemoApi/src/Controllers/OpenApi/OpenApiAuthController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/OpenApi/OpenApiAuthController.php.tpl
@@ -64,9 +64,8 @@ abstract class OpenApiAuthController extends OpenApiController
      *    )
      *  )
      * @param Request $request
-     * @param Response $response
      */
-    abstract public function signin(Request $request, Response $response);
+    abstract public function signin(Request $request);
 
     /**
      * Gets the logged-in user data
@@ -94,9 +93,8 @@ abstract class OpenApiAuthController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Response $response
      */
-    abstract public function me(Response $response);
+    abstract public function me();
 
     /**
      * Sign out action
@@ -134,9 +132,8 @@ abstract class OpenApiAuthController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Response $response
      */
-    abstract public function signout(Response $response);
+    abstract public function signout();
 
     /**
      * Sign up action
@@ -186,9 +183,8 @@ abstract class OpenApiAuthController extends OpenApiController
      *    )
      *  )
      * @param Request $request
-     * @param Response $response
      */
-    abstract public function signup(Request $request, Response $response);
+    abstract public function signup(Request $request);
 
     /**
      * Activate action
@@ -223,9 +219,8 @@ abstract class OpenApiAuthController extends OpenApiController
      *    )
      *  )
      * @param Request $request
-     * @param Response $response
      */
-    abstract public function activate(Request $request, Response $response);
+    abstract public function activate(Request $request);
 
     /**
      * Forget action
@@ -263,9 +258,8 @@ abstract class OpenApiAuthController extends OpenApiController
      *    )
      *  )
      * @param Request $request
-     * @param Response $response
      */
-    abstract public function forget(Request $request, Response $response);
+    abstract public function forget(Request $request);
 
     /**
      * Reset action
@@ -316,9 +310,8 @@ abstract class OpenApiAuthController extends OpenApiController
      *    )
      *  )
      * @param Request $request
-     * @param Response $response
      */
-    abstract public function reset(Request $request, Response $response);
+    abstract public function reset(Request $request);
 
     /**
      * Verify action
@@ -356,9 +349,8 @@ abstract class OpenApiAuthController extends OpenApiController
      *    )
      *  )
      * @param Request $request
-     * @param Response $response
      */
-    abstract public function verify(Request $request, Response $response);
+    abstract public function verify(Request $request);
 
     /**
      * Resend action
@@ -392,7 +384,6 @@ abstract class OpenApiAuthController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Response $response
      */
-    abstract public function resend(Response $response);
+    abstract public function resend();
 }

--- a/src/Module/Templates/DemoApi/src/Controllers/OpenApi/OpenApiPostController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/OpenApi/OpenApiPostController.php.tpl
@@ -225,7 +225,7 @@ abstract class OpenApiPostController extends OpenApiController
      *    )
      *  )
      */
-    abstract public function amend(Request $request,  ?string $lang, string $postId);
+    abstract public function amend(Request $request, ?string $lang, string $postId);
 
     /**
      * Delete post action

--- a/src/Module/Templates/DemoApi/src/Controllers/OpenApi/OpenApiPostController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/OpenApi/OpenApiPostController.php.tpl
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Controllers\OpenApi;
@@ -43,7 +43,6 @@ abstract class OpenApiPostController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Request $request
      */
     abstract public function posts(Request $request);
 
@@ -79,8 +78,6 @@ abstract class OpenApiPostController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param string|null $lang
-     * @param string $postId
      */
     abstract public function post(?string $lang, string $postId);
 
@@ -164,7 +161,6 @@ abstract class OpenApiPostController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Request $request
      */
     abstract public function create(Request $request);
 
@@ -228,9 +224,6 @@ abstract class OpenApiPostController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Request $request
-     * @param string|null $lang
-     * @param string $postId
      */
     abstract public function amend(Request $request,  ?string $lang, string $postId);
 
@@ -273,8 +266,6 @@ abstract class OpenApiPostController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param string|null $lang
-     * @param string $postId
      */
     abstract public function delete(?string $lang, string $postId);
 
@@ -317,8 +308,6 @@ abstract class OpenApiPostController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param string|null $lang
-     * @param string $postId
      */
     abstract public function deleteImage(?string $lang, string $postId);
 

--- a/src/Module/Templates/DemoApi/src/Controllers/OpenApi/OpenApiPostController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/OpenApi/OpenApiPostController.php.tpl
@@ -44,9 +44,8 @@ abstract class OpenApiPostController extends OpenApiController
      *    )
      *  )
      * @param Request $request
-     * @param Response $response
      */
-    abstract public function posts(Request $request, Response $response);
+    abstract public function posts(Request $request);
 
     /**
      * Get post action
@@ -82,9 +81,8 @@ abstract class OpenApiPostController extends OpenApiController
      *  )
      * @param string|null $lang
      * @param string $postId
-     * @param Response $response
      */
-    abstract public function post(?string $lang, string $postId, Response $response);
+    abstract public function post(?string $lang, string $postId);
 
     /**
      * Get my posts action
@@ -112,9 +110,8 @@ abstract class OpenApiPostController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Response $response
      */
-    abstract public function myPosts(Response $response);
+    abstract public function myPosts();
 
     /**
      * Create post action
@@ -168,9 +165,8 @@ abstract class OpenApiPostController extends OpenApiController
      *    )
      *  )
      * @param Request $request
-     * @param Response $response
      */
-    abstract public function create(Request $request, Response $response);
+    abstract public function create(Request $request);
 
     /**
      * Amend post action
@@ -233,11 +229,10 @@ abstract class OpenApiPostController extends OpenApiController
      *    )
      *  )
      * @param Request $request
-     * @param Response $response
      * @param string|null $lang
      * @param string $postId
      */
-    abstract public function amend(Request $request, Response $response, ?string $lang, string $postId);
+    abstract public function amend(Request $request,  ?string $lang, string $postId);
 
     /**
      * Delete post action
@@ -278,11 +273,10 @@ abstract class OpenApiPostController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Response $response
      * @param string|null $lang
      * @param string $postId
      */
-    abstract public function delete(Response $response, ?string $lang, string $postId);
+    abstract public function delete(?string $lang, string $postId);
 
     /**
      * Delete post image action
@@ -323,10 +317,9 @@ abstract class OpenApiPostController extends OpenApiController
      *      description="Internal Server Error"
      *    )
      *  )
-     * @param Response $response
      * @param string|null $lang
      * @param string $postId
      */
-    abstract public function deleteImage(Response $response, ?string $lang, string $postId);
+    abstract public function deleteImage(?string $lang, string $postId);
 
 }

--- a/src/Module/Templates/DemoApi/src/Controllers/PostController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/PostController.php.tpl
@@ -53,10 +53,9 @@ class PostController extends BaseController
     /**
      * Action - get posts list
      * @param Request $request
-     * @param Response $response
      * @return Response
      */
-    public function posts(Request $request, Response $response): Response
+    public function posts(Request $request): Response
     {
         $perPage = $request->get('per_page', (string) self::POSTS_PER_PAGE);
         $currentPage = $request->get('page', (string) self::CURRENT_PAGE);
@@ -64,7 +63,7 @@ class PostController extends BaseController
 
         $paginatedPosts = $this->postService->getPosts($perPage, $currentPage, $search);
 
-        return $response->json([
+        return response()->json([
             'status' => 'success',
             'data' => $this->postService->transformData($paginatedPosts->data()->all()),
             'pagination' => [
@@ -78,17 +77,16 @@ class PostController extends BaseController
 
     /**
      * Action - get single post
-     * @param Response $response
      * @param string|null $lang
      * @param string $postUuid
      * @return Response
      */
-    public function post(Response $response, ?string $lang, string $postUuid): Response
+    public function post(?string $lang, string $postUuid): Response
     {
         $post = $this->postService->getPost($postUuid);
 
         if ($post->isEmpty()) {
-            return $response->json([
+            return response()->json([
                 'status' => 'error',
                 'message' => t('common.post_not_found')
             ], StatusCode::NOT_FOUND);

--- a/src/Module/Templates/DemoApi/src/Controllers/PostController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/PostController.php.tpl
@@ -41,7 +41,6 @@ class PostController extends BaseController
 
     /**
      * Post service
-     * @var PostService
      */
     public PostService $postService;
 
@@ -52,8 +51,6 @@ class PostController extends BaseController
 
     /**
      * Action - get posts list
-     * @param Request $request
-     * @return Response
      */
     public function posts(Request $request): Response
     {
@@ -77,9 +74,6 @@ class PostController extends BaseController
 
     /**
      * Action - get single post
-     * @param string|null $lang
-     * @param string $postUuid
-     * @return Response
      */
     public function post(?string $lang, string $postUuid): Response
     {

--- a/src/Module/Templates/DemoApi/src/Controllers/PostController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/PostController.php.tpl
@@ -96,7 +96,7 @@ class PostController extends BaseController
 
         $postData['comments'] = $commentsData;
 
-        return $response->json([
+        return response()->json([
             'status' => 'success',
             'data' => $postData,
         ]);

--- a/src/Module/Templates/DemoApi/src/Controllers/PostManagementController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/PostManagementController.php.tpl
@@ -42,14 +42,13 @@ class PostManagementController extends BaseController
 
     /**
      * Action - get my posts
-     * @param Response $response
      * @return Response
      */
-    public function myPosts(Response $response): Response
+    public function myPosts(): Response
     {
         $myPosts = $this->postService->getMyPosts(auth()->user()->uuid);
-        
-        return $response->json([
+
+        return response()->json([
             'status' => 'success',
             'data' => $this->postService->transformData($myPosts->all())
         ]);
@@ -57,12 +56,12 @@ class PostManagementController extends BaseController
 
     /**
      * Action - create post
-     * @param Request $request 
-     * @param Response $response
+     * @param Request $request
      * @return Response
      */
-    public function create(Request $request, Response $response): Response
+    public function create(Request $request): Response
     {
+        $response = response();
         $imageName = '';
 
         if ($request->hasFile('image')) {
@@ -85,15 +84,15 @@ class PostManagementController extends BaseController
     }
 
     /**
-     * Action - amend post 
-     * @param Request $request 
-     * @param Response $response
+     * Action - amend post
+     * @param Request $request
      * @param string|null $lang
      * @param string $postUuid
      * @return Response
      */
-    public function amend(Request $request, Response $response, ?string $lang, string $postUuid): Response
+    public function amend(Request $request,  ?string $lang, string $postUuid): Response
     {
+        $response = response();
         $post = $this->postService->getPost($postUuid);
 
         $imageName = null;
@@ -123,13 +122,13 @@ class PostManagementController extends BaseController
 
     /**
      * Action - delete post
-     * @param Response $response
      * @param string|null $lang
      * @param string $postUuid
      * @return Response
      */
-    public function delete(Response $response, ?string $lang, string $postUuid): Response
+    public function delete(?string $lang, string $postUuid): Response
     {
+        $response = response();
         $post = $this->postService->getPost($postUuid);
 
         if ($post->image) {
@@ -146,13 +145,13 @@ class PostManagementController extends BaseController
 
     /**
      * Action - delete image of the post
-     * @param Response $response
-     * @param string|null $lang 
+     * @param string|null $lang
      * @param string $postUuid
      * @return Response
      */
-    public function deleteImage(Response $response, ?string $lang, string $postUuid): Response
+    public function deleteImage(?string $lang, string $postUuid): Response
     {
+        $response = response();
         $post = $this->postService->getPost($postUuid);
 
         if ($post->image) {

--- a/src/Module/Templates/DemoApi/src/Controllers/PostManagementController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/PostManagementController.php.tpl
@@ -81,7 +81,7 @@ class PostManagementController extends BaseController
     /**
      * Action - amend post
      */
-    public function amend(Request $request,  ?string $lang, string $postUuid): Response
+    public function amend(Request $request, ?string $lang, string $postUuid): Response
     {
         $post = $this->postService->getPost($postUuid);
 

--- a/src/Module/Templates/DemoApi/src/Controllers/PostManagementController.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Controllers/PostManagementController.php.tpl
@@ -31,7 +31,6 @@ class PostManagementController extends BaseController
 
     /**
      * Post service
-     * @var PostService
      */
     public PostService $postService;
 
@@ -42,7 +41,6 @@ class PostManagementController extends BaseController
 
     /**
      * Action - get my posts
-     * @return Response
      */
     public function myPosts(): Response
     {
@@ -56,12 +54,9 @@ class PostManagementController extends BaseController
 
     /**
      * Action - create post
-     * @param Request $request
-     * @return Response
      */
     public function create(Request $request): Response
     {
-        $response = response();
         $imageName = '';
 
         if ($request->hasFile('image')) {
@@ -76,7 +71,7 @@ class PostManagementController extends BaseController
 
         $post = $this->postService->addPost($postDto);
 
-        return $response->json([
+        return response()->json([
             'status' => 'success',
             'message' => t('common.created_successfully'),
             'data' => current($this->postService->transformData([$post]))
@@ -85,14 +80,9 @@ class PostManagementController extends BaseController
 
     /**
      * Action - amend post
-     * @param Request $request
-     * @param string|null $lang
-     * @param string $postUuid
-     * @return Response
      */
     public function amend(Request $request,  ?string $lang, string $postUuid): Response
     {
-        $response = response();
         $post = $this->postService->getPost($postUuid);
 
         $imageName = null;
@@ -113,7 +103,7 @@ class PostManagementController extends BaseController
 
         $post = $this->postService->updatePost($postUuid, $postDto);
 
-        return $response->json([
+        return response()->json([
             'status' => 'success',
             'message' => t('common.updated_successfully'),
             'data' => current($this->postService->transformData([$post]))
@@ -122,13 +112,9 @@ class PostManagementController extends BaseController
 
     /**
      * Action - delete post
-     * @param string|null $lang
-     * @param string $postUuid
-     * @return Response
      */
     public function delete(?string $lang, string $postUuid): Response
     {
-        $response = response();
         $post = $this->postService->getPost($postUuid);
 
         if ($post->image) {
@@ -137,7 +123,7 @@ class PostManagementController extends BaseController
 
         $this->postService->deletePost($postUuid);
 
-        return $response->json([
+        return response()->json([
             'status' => 'success',
             'message' => t('common.deleted_successfully')
         ]);
@@ -145,13 +131,9 @@ class PostManagementController extends BaseController
 
     /**
      * Action - delete image of the post
-     * @param string|null $lang
-     * @param string $postUuid
-     * @return Response
      */
     public function deleteImage(?string $lang, string $postUuid): Response
     {
-        $response = response();
         $post = $this->postService->getPost($postUuid);
 
         if ($post->image) {
@@ -167,7 +149,7 @@ class PostManagementController extends BaseController
 
         $this->postService->updatePost($postUuid, $postDto);
 
-        return $response->json([
+        return response()->json([
             'status' => 'success',
             'message' => t('common.deleted_successfully')
         ]);

--- a/src/Module/Templates/DemoApi/src/Middlewares/Activate.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Activate.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Middlewares/Activate.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Activate.php.tpl
@@ -29,18 +29,16 @@ class Activate extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         $token = (string)route_param('token');
 
         $request->set('token', $token);
 
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 

--- a/src/Module/Templates/DemoApi/src/Middlewares/Activate.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Activate.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -26,12 +26,6 @@ use Closure;
  */
 class Activate extends BaseMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         $token = (string)route_param('token');

--- a/src/Module/Templates/DemoApi/src/Middlewares/Auth.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Auth.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Middlewares/Auth.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Auth.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -25,12 +25,6 @@ use Closure;
  */
 class Auth extends BaseMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if (!auth()->check()) {

--- a/src/Module/Templates/DemoApi/src/Middlewares/Auth.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Auth.php.tpl
@@ -25,20 +25,16 @@ use Closure;
  */
 class Auth extends BaseMiddleware
 {
-    
+
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         if (!auth()->check()) {
-            $this->respondWithError(
-                $request,
-                $response,
+            $this->respondWithError($request,
                 t('validation.unauthorizedRequest'),
                 StatusCode::UNAUTHORIZED
             );

--- a/src/Module/Templates/DemoApi/src/Middlewares/BaseMiddleware.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/BaseMiddleware.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Middlewares/BaseMiddleware.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/BaseMiddleware.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -27,15 +27,10 @@ use Closure;
  */
 abstract class BaseMiddleware extends QtMiddleware
 {
-
-    /**
-     * @var Validator
-     */
     protected $validator;
 
     /**
      * BaseMiddleware constructor.
-     * @param Request $request
      */
     public function __construct(Request $request)
     {
@@ -46,7 +41,6 @@ abstract class BaseMiddleware extends QtMiddleware
 
     /**
      * Define validation rules specific to middleware.
-     * @param Request $request
      */
     protected function defineValidationRules(Request $request)
     {
@@ -55,7 +49,6 @@ abstract class BaseMiddleware extends QtMiddleware
 
     /**
      * Validate the request and respond with error if invalid.
-     * @param Request $request
      * @return Response|null
      */
     protected function validateRequest(Request $request): ?Response
@@ -69,10 +62,6 @@ abstract class BaseMiddleware extends QtMiddleware
 
     /**
      * Handles error response logic.
-     * @param Request $request
-     * @param mixed $message
-     * @param int $status
-     * @return Response
      */
     protected function respondWithError(Request $request,
         $message,

--- a/src/Module/Templates/DemoApi/src/Middlewares/BaseMiddleware.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/BaseMiddleware.php.tpl
@@ -56,13 +56,12 @@ abstract class BaseMiddleware extends QtMiddleware
     /**
      * Validate the request and respond with error if invalid.
      * @param Request $request
-     * @param Response $response
      * @return Response|null
      */
-    protected function validateRequest(Request $request, Response $response): ?Response
+    protected function validateRequest(Request $request): ?Response
     {
         if (!$this->validator->isValid($request->all())) {
-            return $this->respondWithError($request, $response, $this->validator->getErrors());
+            return $this->respondWithError($request, $this->validator->getErrors());
         }
 
         return null;
@@ -71,19 +70,16 @@ abstract class BaseMiddleware extends QtMiddleware
     /**
      * Handles error response logic.
      * @param Request $request
-     * @param Response $response
      * @param mixed $message
      * @param int $status
      * @return Response
      */
-    protected function respondWithError(
-        Request $request,
-        Response $response,
+    protected function respondWithError(Request $request,
         $message,
         int $status = StatusCode::UNPROCESSABLE_ENTITY
     ): Response
     {
-        return $response->json([
+        return response()->json([
             'status' => 'error',
             'message' => $message,
         ], $status);

--- a/src/Module/Templates/DemoApi/src/Middlewares/Comment.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Comment.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Middlewares/Comment.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Comment.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.9
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -25,11 +25,6 @@ use Closure;
  */
 class Comment extends BaseMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if ($errorResponse = $this->validateRequest($request)) {

--- a/src/Module/Templates/DemoApi/src/Middlewares/Comment.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Comment.php.tpl
@@ -28,13 +28,11 @@ class Comment extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 

--- a/src/Module/Templates/DemoApi/src/Middlewares/CommentOwner.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/CommentOwner.php.tpl
@@ -29,18 +29,16 @@ class CommentOwner extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         $uuid = (string)route_param('uuid');
 
         $request->set('uuid', $uuid);
 
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 

--- a/src/Module/Templates/DemoApi/src/Middlewares/CommentOwner.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/CommentOwner.php.tpl
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.9
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -26,12 +26,6 @@ use Closure;
  */
 class CommentOwner extends BaseMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         $uuid = (string)route_param('uuid');

--- a/src/Module/Templates/DemoApi/src/Middlewares/Editor.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Editor.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Middlewares/Editor.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Editor.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -42,11 +42,6 @@ class Editor extends BaseMiddleware
      */
     private const ALLOWED_IMAGE_EXTENSIONS = ['jpeg', 'jpg', 'png'];
 
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if (!in_array(auth()->user()->role, self::ROLES)) {

--- a/src/Module/Templates/DemoApi/src/Middlewares/Editor.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Editor.php.tpl
@@ -44,24 +44,20 @@ class Editor extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         if (!in_array(auth()->user()->role, self::ROLES)) {
-            return $this->respondWithError(
-                $request,
-                $response,
+            return $this->respondWithError($request,
                 t('validation.unauthorizedRequest'),
                 StatusCode::UNAUTHORIZED
             );
         }
 
         if ($request->isMethod('post') || $request->isMethod('put')) {
-            if ($errorResponse = $this->validateRequest($request, $response)) {
+            if ($errorResponse = $this->validateRequest($request)) {
                 return $errorResponse;
             }
         }

--- a/src/Module/Templates/DemoApi/src/Middlewares/Forget.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Forget.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Middlewares/Forget.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Forget.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -26,13 +26,6 @@ use Closure;
  */
 class Forget extends BaseMiddleware
 {
-
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if ($request->isMethod('post')) {

--- a/src/Module/Templates/DemoApi/src/Middlewares/Forget.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Forget.php.tpl
@@ -30,15 +30,13 @@ class Forget extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         if ($request->isMethod('post')) {
-            if ($errorResponse = $this->validateRequest($request, $response)) {
+            if ($errorResponse = $this->validateRequest($request)) {
                 return $errorResponse;
             }
         }

--- a/src/Module/Templates/DemoApi/src/Middlewares/Password.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Password.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Middlewares/Password.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Password.php.tpl
@@ -30,14 +30,12 @@ class Password extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         if ($request->isMethod('post')) {
-            if ($errorResponse = $this->validateRequest($request, $response)) {
+            if ($errorResponse = $this->validateRequest($request)) {
                 return $errorResponse;
             }
         }

--- a/src/Module/Templates/DemoApi/src/Middlewares/Password.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Password.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.9
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -27,11 +27,6 @@ use Closure;
  */
 class Password extends BaseMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if ($request->isMethod('post')) {
@@ -68,7 +63,6 @@ class Password extends BaseMiddleware
 
     /**
      * Registers custom validation rules
-     * @param Request $request
      */
     private function registerCustomRules(Request $request)
     {

--- a/src/Module/Templates/DemoApi/src/Middlewares/PostOwner.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/PostOwner.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Middlewares/PostOwner.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/PostOwner.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.9
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -26,12 +26,6 @@ use Closure;
  */
 class PostOwner extends BaseMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         $uuid = (string)route_param('uuid');

--- a/src/Module/Templates/DemoApi/src/Middlewares/PostOwner.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/PostOwner.php.tpl
@@ -29,18 +29,16 @@ class PostOwner extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         $uuid = (string)route_param('uuid');
 
         $request->set('uuid', $uuid);
 
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 

--- a/src/Module/Templates/DemoApi/src/Middlewares/Resend.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Resend.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Middlewares/Resend.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Resend.php.tpl
@@ -29,18 +29,16 @@ class Resend extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         $code = (string) route_param('code');
 
         $request->set('code', $code);
 
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 

--- a/src/Module/Templates/DemoApi/src/Middlewares/Resend.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Resend.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -25,13 +25,6 @@ use Closure;
  */
 class Resend extends BaseMiddleware
 {
-
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         $code = (string) route_param('code');

--- a/src/Module/Templates/DemoApi/src/Middlewares/Reset.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Reset.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Middlewares/Reset.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Reset.php.tpl
@@ -29,18 +29,16 @@ class Reset extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         $token = (string) route_param('token');
 
         $request->set('token', $token);
 
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 

--- a/src/Module/Templates/DemoApi/src/Middlewares/Reset.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Reset.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -26,12 +26,6 @@ use Closure;
  */
 class Reset extends BaseMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         $token = (string) route_param('token');

--- a/src/Module/Templates/DemoApi/src/Middlewares/Signout.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Signout.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Middlewares/Signout.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Signout.php.tpl
@@ -11,7 +11,7 @@
  * @link http://quantum.softberg.org/
  * @since 2.9.8
  */
- 
+
 namespace {{MODULE_NAMESPACE}}\Middlewares;
 
 use Quantum\Http\Response;
@@ -27,17 +27,13 @@ class Signout extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         if (!$request->hasHeader('refresh_token')) {
-            $this->respondWithError(
-                $request,
-                $response,
+            $this->respondWithError($request,
                 [t('validation.nonExistingRecord', 'token')]
             );
         }

--- a/src/Module/Templates/DemoApi/src/Middlewares/Signout.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Signout.php.tpl
@@ -27,7 +27,7 @@ class Signout extends BaseMiddleware
     public function apply(Request $request, Closure $next): Response
     {
         if (!$request->hasHeader('refresh_token')) {
-            $this->respondWithError($request,
+            return $this->respondWithError($request,
                 [t('validation.nonExistingRecord', 'token')]
             );
         }

--- a/src/Module/Templates/DemoApi/src/Middlewares/Signout.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Signout.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -24,12 +24,6 @@ use Closure;
  */
 class Signout extends BaseMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if (!$request->hasHeader('refresh_token')) {

--- a/src/Module/Templates/DemoApi/src/Middlewares/Signup.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Signup.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Middlewares/Signup.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Signup.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -26,13 +26,6 @@ use Closure;
  */
 class Signup extends BaseMiddleware
 {
-
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if ($errorResponse = $this->validateRequest($request)) {

--- a/src/Module/Templates/DemoApi/src/Middlewares/Signup.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Signup.php.tpl
@@ -30,14 +30,12 @@ class Signup extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 

--- a/src/Module/Templates/DemoApi/src/Middlewares/Update.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Update.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Middlewares/Update.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Update.php.tpl
@@ -29,14 +29,12 @@ class Update extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         if ($request->isMethod('post')) {
-            if ($errorResponse = $this->validateRequest($request, $response)) {
+            if ($errorResponse = $this->validateRequest($request)) {
                 return $errorResponse;
             }
         }

--- a/src/Module/Templates/DemoApi/src/Middlewares/Update.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Update.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -25,12 +25,6 @@ use Closure;
  */
 class Update extends BaseMiddleware
 {
-
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if ($request->isMethod('post')) {

--- a/src/Module/Templates/DemoApi/src/Middlewares/Verify.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Verify.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoApi/src/Middlewares/Verify.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Verify.php.tpl
@@ -30,15 +30,13 @@ class Verify extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         if ($request->isMethod('post')) {
-            if ($errorResponse = $this->validateRequest($request, $response)) {
+            if ($errorResponse = $this->validateRequest($request)) {
                 return $errorResponse;
             }
         }

--- a/src/Module/Templates/DemoApi/src/Middlewares/Verify.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Verify.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -26,13 +26,6 @@ use Closure;
 
 class Verify extends BaseMiddleware
 {
-
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if ($request->isMethod('post')) {

--- a/src/Module/Templates/DemoWeb/src/Controllers/AccountController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/AccountController.php.tpl
@@ -32,7 +32,6 @@ class AccountController extends BaseController
 
     /**
      * Account service
-     * @var AuthService
      */
     public AuthService $authService;
 
@@ -44,7 +43,6 @@ class AccountController extends BaseController
 
     /**
      * Action - show user info
-     * @return Response
      */
     public function form(): Response
     {
@@ -57,8 +55,6 @@ class AccountController extends BaseController
 
     /**
      * Action - update user info
-     * @param Request $request
-     * @return Response
      */
     public function update(Request $request): Response
     {
@@ -77,8 +73,6 @@ class AccountController extends BaseController
 
     /**
      * Action - update password
-     * @param Request $request
-     * @return Response
      */
     public function updatePassword(Request $request): Response
     {

--- a/src/Module/Templates/DemoWeb/src/Controllers/AccountController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/AccountController.php.tpl
@@ -44,16 +44,15 @@ class AccountController extends BaseController
 
     /**
      * Action - show user info
-     * @param Response $response
      * @return Response
      */
-    public function form(Response $response): Response
+    public function form(): Response
     {
         $this->view->setParams([
             'title' => t('common.account_settings') . ' | ' . config()->get('app.name'),
         ]);
 
-        return $response->html($this->view->render('account/form'));
+        return response()->html($this->view->render('account/form'));
     }
 
     /**
@@ -86,7 +85,7 @@ class AccountController extends BaseController
         $hasher = new Hasher();
 
         $newPassword = $request->get('new_password', null);
-        
+
         $this->authService->update('uuid', auth()->user()->uuid, [
             'password' => $hasher->hash($newPassword)
         ]);

--- a/src/Module/Templates/DemoWeb/src/Controllers/AuthController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/AuthController.php.tpl
@@ -26,7 +26,6 @@ use Quantum\Http\Request;
  */
 class AuthController extends BaseController
 {
-
     /**
      * Main layout
      */
@@ -59,12 +58,9 @@ class AuthController extends BaseController
 
     /**
      * Action - sign in
-     * @param Request $request
-     * @return Response
      */
     public function signin(Request $request): Response
     {
-        $response = response();
         if ($request->isMethod('post')) {
             try {
                 $code = auth()->signin($request->get('email'), $request->get('password'), !!$request->get('remember'));
@@ -83,13 +79,12 @@ class AuthController extends BaseController
                 'title' => t('common.signin') . ' | ' . config()->get('app.name'),
             ]);
 
-            return $response->html($this->view->render(self::VIEW_SIGNIN));
+            return response()->html($this->view->render(self::VIEW_SIGNIN));
         }
     }
 
     /**
      * Action - sign out
-     * @return Response
      */
     public function signout(): Response
     {
@@ -99,12 +94,9 @@ class AuthController extends BaseController
 
     /**
      * Action - sign up
-     * @param Request $request
-     * @return Response
      */
     public function signup(Request $request): Response
     {
-        $response = response();
         if ($request->isMethod('post')) {
             $userDto = UserDTO::fromRequest($request, Role::EDITOR, uuid_ordered());
 
@@ -118,14 +110,12 @@ class AuthController extends BaseController
                 'title' => t('common.signup') . ' | ' . config()->get('app.name'),
             ]);
 
-            return $response->html($this->view->render(self::VIEW_SIGNUP));
+            return response()->html($this->view->render(self::VIEW_SIGNUP));
         }
     }
 
     /**
      * Action - activate
-     * @param Request $request
-     * @return Response
      */
     public function activate(Request $request): Response
     {
@@ -135,12 +125,9 @@ class AuthController extends BaseController
 
     /**
      * Action - forget
-     * @param Request $request
-     * @return Response
      */
     public function forget(Request $request): Response
     {
-        $response = response();
         if ($request->isMethod('post')) {
             auth()->forget($request->get('email'));
             session()->setFlash('success', t('common.check_email'));
@@ -150,18 +137,15 @@ class AuthController extends BaseController
                 'title' => t('common.forget_password') . ' | ' . config()->get('app.name'),
             ]);
 
-            return $response->html($this->view->render(self::VIEW_FORGET));
+            return response()->html($this->view->render(self::VIEW_FORGET));
         }
     }
 
     /**
      * Action - reset
-     * @param Request $request
-     * @return Response
      */
     public function reset(Request $request): Response
     {
-        $response = response();
         if ($request->isMethod('post')) {
             auth()->reset($request->get('reset_token'), $request->get('password'));
             return redirect(base_url(true) . '/' . current_lang() . '/signin');
@@ -171,18 +155,15 @@ class AuthController extends BaseController
                 'reset_token' => $request->get('reset_token')
             ]);
 
-            return $response->html($this->view->render(self::VIEW_RESET));
+            return response()->html($this->view->render(self::VIEW_RESET));
         }
     }
 
     /**
      * Action - Verify OTP
-     * @param Request $request
-     * @return Response
      */
     public function verify(Request $request): Response
     {
-        $response = response();
         if ($request->isMethod('post')) {
             try {
                 auth()->verifyOtp((int)$request->get('otp'), $request->get('code'));
@@ -197,13 +178,12 @@ class AuthController extends BaseController
                 'code' => route_param('code')
             ]);
 
-            return $response->html($this->view->render(self::VIEW_VERIFY));
+            return response()->html($this->view->render(self::VIEW_VERIFY));
         }
     }
 
     /**
      * Action - Resend OTP
-     * @return Response
      */
     public function resend(): Response
     {

--- a/src/Module/Templates/DemoWeb/src/Controllers/AuthController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/AuthController.php.tpl
@@ -60,11 +60,11 @@ class AuthController extends BaseController
     /**
      * Action - sign in
      * @param Request $request
-     * @param Response $response
      * @return Response
      */
-    public function signin(Request $request, Response $response): Response
+    public function signin(Request $request): Response
     {
+        $response = response();
         if ($request->isMethod('post')) {
             try {
                 $code = auth()->signin($request->get('email'), $request->get('password'), !!$request->get('remember'));
@@ -100,11 +100,11 @@ class AuthController extends BaseController
     /**
      * Action - sign up
      * @param Request $request
-     * @param Response $response
      * @return Response
      */
-    public function signup(Request $request, Response $response): Response
+    public function signup(Request $request): Response
     {
+        $response = response();
         if ($request->isMethod('post')) {
             $userDto = UserDTO::fromRequest($request, Role::EDITOR, uuid_ordered());
 
@@ -136,11 +136,11 @@ class AuthController extends BaseController
     /**
      * Action - forget
      * @param Request $request
-     * @param Response $response
      * @return Response
      */
-    public function forget(Request $request, Response $response): Response
+    public function forget(Request $request): Response
     {
+        $response = response();
         if ($request->isMethod('post')) {
             auth()->forget($request->get('email'));
             session()->setFlash('success', t('common.check_email'));
@@ -157,11 +157,11 @@ class AuthController extends BaseController
     /**
      * Action - reset
      * @param Request $request
-     * @param Response $response
      * @return Response
      */
-    public function reset(Request $request, Response $response): Response
+    public function reset(Request $request): Response
     {
+        $response = response();
         if ($request->isMethod('post')) {
             auth()->reset($request->get('reset_token'), $request->get('password'));
             return redirect(base_url(true) . '/' . current_lang() . '/signin');
@@ -178,11 +178,11 @@ class AuthController extends BaseController
     /**
      * Action - Verify OTP
      * @param Request $request
-     * @param Response $response
      * @return Response
      */
-    public function verify(Request $request, Response $response): Response
+    public function verify(Request $request): Response
     {
+        $response = response();
         if ($request->isMethod('post')) {
             try {
                 auth()->verifyOtp((int)$request->get('otp'), $request->get('code'));

--- a/src/Module/Templates/DemoWeb/src/Controllers/BaseController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/BaseController.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoWeb/src/Controllers/BaseController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/BaseController.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -24,10 +24,6 @@ use Quantum\View\View;
  */
 abstract class BaseController
 {
-
-    /**
-    * @var View
-    */
     protected View $view;
 
     public function __before()

--- a/src/Module/Templates/DemoWeb/src/Controllers/CommentController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/CommentController.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoWeb/src/Controllers/CommentController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/CommentController.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -24,19 +24,8 @@ use Quantum\Http\Request;
  */
 class CommentController extends BaseController
 {
-
-    /**
-     * @var CommentService
-     */
     public CommentService $commentService;
 
-    /**
-     * @return void
-     * @throws ReflectionException
-     * @throws \Quantum\App\Exceptions\BaseException
-     * @throws \Quantum\Di\Exceptions\DiException
-     * @throws \Quantum\Service\Exceptions\ServiceException
-     */
     public function __before()
     {
         $this->commentService = service(CommentService::class);
@@ -45,10 +34,6 @@ class CommentController extends BaseController
 
     /**
      * Action - create comment
-     * @param Request $request
-     * @param string|null $lang
-     * @param string $uuid
-     * @return Response
      */
     public function create(Request $request, ?string $lang, string $uuid): Response
     {
@@ -62,9 +47,6 @@ class CommentController extends BaseController
 
     /**
      * Action - delete comment
-     * @param string|null $lang
-     * @param string $uuid
-     * @return Response
      */
     public function delete(?string $lang, string $uuid): Response
     {

--- a/src/Module/Templates/DemoWeb/src/Controllers/PageController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/PageController.php.tpl
@@ -30,23 +30,21 @@ class PageController extends BaseController
     protected const LAYOUT = 'layouts/main';
 
     /**
-     * Action - display home page  
-     * @param Response $response
+     * Action - display home page
      */
-    public function home(Response $response): Response
+    public function home(): Response
     {
         $this->view->setParams([
             'title' => config()->get('app.name'),
         ]);
 
-        return $response->html($this->view->render('pages/index'));
+        return response()->html($this->view->render('pages/index'));
     }
 
     /**
-     * Action - display about page 
-     * @param Response $response
+     * Action - display about page
      */
-    public function about(Response $response): Response
+    public function about(): Response
     {
         $this->view->setParams([
             'title' => t('common.about') . ' | ' . config()->get('app.name'),
@@ -54,6 +52,6 @@ class PageController extends BaseController
 
         $commands = service(CommandService::class)->getAllCommands();
 
-        return $response->html($this->view->render('pages/about', ['commands' => $commands]));
+        return response()->html($this->view->render('pages/about', ['commands' => $commands]));
     }
 }

--- a/src/Module/Templates/DemoWeb/src/Controllers/PostController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/PostController.php.tpl
@@ -77,7 +77,7 @@ class PostController extends BaseController
     /**
      * Action - get single post
      */
-    public function post(Request $request,  ?string $lang, string $postUuid): Response
+    public function post(Request $request, ?string $lang, string $postUuid): Response
     {
         $ref = $request->get('ref', 'posts');
 
@@ -100,6 +100,6 @@ class PostController extends BaseController
             'referer' => nav_ref_decode($ref),
         ]);
 
-        return $response->html($this->view->render('post/single'));
+        return response()->html($this->view->render('post/single'));
     }
 }

--- a/src/Module/Templates/DemoWeb/src/Controllers/PostController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/PostController.php.tpl
@@ -27,7 +27,6 @@ use Quantum\Http\Request;
  */
 class PostController extends BaseController
 {
-
     /**
      * Posts per page
      */
@@ -45,7 +44,6 @@ class PostController extends BaseController
 
     /**
      * Post service
-     * @var PostService
      */
     public PostService $postService;
 
@@ -57,8 +55,6 @@ class PostController extends BaseController
 
     /**
      * Action - get posts list
-     * @param Request $request
-     * @return Response
     */
     public function posts(Request $request): Response
     {
@@ -80,10 +76,6 @@ class PostController extends BaseController
 
     /**
      * Action - get single post
-     * @param Request $request
-     * @param string|null $lang
-     * @param string $postUuid
-     * @return Response
      */
     public function post(Request $request,  ?string $lang, string $postUuid): Response
     {

--- a/src/Module/Templates/DemoWeb/src/Controllers/PostController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/PostController.php.tpl
@@ -37,12 +37,12 @@ class PostController extends BaseController
      * Current page
      */
     protected const CURRENT_PAGE = 1;
-    
+
     /**
      * Main layout
      */
     protected const LAYOUT = 'layouts/main';
-    
+
     /**
      * Post service
      * @var PostService
@@ -58,10 +58,9 @@ class PostController extends BaseController
     /**
      * Action - get posts list
      * @param Request $request
-     * @param Response $response
      * @return Response
     */
-    public function posts(Request $request, Response $response): Response
+    public function posts(Request $request): Response
     {
         $perPage = $request->get('per_page', (string) self::POSTS_PER_PAGE);
         $currentPage = $request->get('page', (string) self::CURRENT_PAGE);
@@ -76,25 +75,24 @@ class PostController extends BaseController
             'referer' => nav_ref_encode(request()->getQuery())
         ]);
 
-        return $response->html($this->view->render('post/post'));
+        return response()->html($this->view->render('post/post'));
     }
 
     /**
      * Action - get single post
      * @param Request $request
-     * @param Response $response
      * @param string|null $lang
      * @param string $postUuid
      * @return Response
      */
-    public function post(Request $request, Response $response, ?string $lang, string $postUuid): Response
+    public function post(Request $request,  ?string $lang, string $postUuid): Response
     {
         $ref = $request->get('ref', 'posts');
-    
+
         $post = $this->postService->getPost($postUuid);
-        
+
         if ($post->isEmpty()) {
-            return $response->html(partial('errors/404'), StatusCode::NOT_FOUND);
+            return response()->html(partial('errors/404'), StatusCode::NOT_FOUND);
         }
 
         $commentService = service(CommentService::class);

--- a/src/Module/Templates/DemoWeb/src/Controllers/PostManagementController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/PostManagementController.php.tpl
@@ -25,12 +25,12 @@ use Quantum\Http\Request;
  */
 class PostManagementController extends BaseController
 {
-    
+
     /**
      * Main layout
      */
     protected const LAYOUT = 'layouts/main';
-    
+
     /**
      * Post service
      * @var PostService
@@ -46,10 +46,9 @@ class PostManagementController extends BaseController
     /**
      * Action - get my posts
      * @param Request $request
-     * @param Response $response
      * @return Response
      */
-    public function myPosts(Request $request, Response $response): Response
+    public function myPosts(Request $request): Response
     {
         $myPosts = $this->postService->getMyPosts(auth()->user()->uuid);
 
@@ -58,16 +57,15 @@ class PostManagementController extends BaseController
             'posts' => $this->postService->transformData($myPosts->all())
         ]);
 
-        return $response->html($this->view->render('post/my-posts'));
+        return response()->html($this->view->render('post/my-posts'));
     }
 
     /**
      * Action - display form for creating a post
      * @param Request $request
-     * @param Response $response
      * @return Response
      */
-    public function createFrom(Request $request, Response $response): Response
+    public function createFrom(Request $request): Response
     {
         $ref = $request->get('ref', 'posts');
 
@@ -76,7 +74,7 @@ class PostManagementController extends BaseController
             'referer' => $ref
         ]);
 
-        return $response->html($this->view->render('post/form'));
+        return response()->html($this->view->render('post/form'));
     }
 
     /**
@@ -104,14 +102,13 @@ class PostManagementController extends BaseController
     }
 
     /**
-     * Action - display form for amend the post 
+     * Action - display form for amend the post
      * @param Request $request
-     * @param Response $response
      * @param string|null $lang
      * @param string $postUuid
      * @return Response
      */
-    public function amendForm(Request $request, Response $response, ?string $lang, string $postUuid): Response
+    public function amendForm(Request $request,  ?string $lang, string $postUuid): Response
     {
         $ref = $request->get('ref', 'posts');
 
@@ -123,11 +120,11 @@ class PostManagementController extends BaseController
             'referer' => nav_ref_decode($ref)
         ]);
 
-        return $response->html($this->view->render('post/form'));
+        return response()->html($this->view->render('post/form'));
     }
 
     /**
-     * Action - amend post 
+     * Action - amend post
      * @param Request $request
      * @param string|null $lang
      * @param string $postUuid

--- a/src/Module/Templates/DemoWeb/src/Controllers/PostManagementController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/PostManagementController.php.tpl
@@ -25,7 +25,6 @@ use Quantum\Http\Request;
  */
 class PostManagementController extends BaseController
 {
-
     /**
      * Main layout
      */
@@ -33,7 +32,6 @@ class PostManagementController extends BaseController
 
     /**
      * Post service
-     * @var PostService
      */
     public PostService $postService;
 
@@ -45,8 +43,6 @@ class PostManagementController extends BaseController
 
     /**
      * Action - get my posts
-     * @param Request $request
-     * @return Response
      */
     public function myPosts(Request $request): Response
     {
@@ -62,8 +58,6 @@ class PostManagementController extends BaseController
 
     /**
      * Action - display form for creating a post
-     * @param Request $request
-     * @return Response
      */
     public function createFrom(Request $request): Response
     {
@@ -79,8 +73,6 @@ class PostManagementController extends BaseController
 
     /**
      * Action - create post
-     * @param Request $request
-     * @return Response
      */
     public function create(Request $request): Response
     {
@@ -103,10 +95,6 @@ class PostManagementController extends BaseController
 
     /**
      * Action - display form for amend the post
-     * @param Request $request
-     * @param string|null $lang
-     * @param string $postUuid
-     * @return Response
      */
     public function amendForm(Request $request,  ?string $lang, string $postUuid): Response
     {
@@ -125,10 +113,6 @@ class PostManagementController extends BaseController
 
     /**
      * Action - amend post
-     * @param Request $request
-     * @param string|null $lang
-     * @param string $postUuid
-     * @return Response
      */
     public function amend(Request $request, ?string $lang, string $postUuid): Response
     {
@@ -157,9 +141,6 @@ class PostManagementController extends BaseController
 
     /**
      * Action - delete post
-     * @param string|null $lang
-     * @param string $postUuid
-     * @return Response
      */
     public function delete(?string $lang, string $postUuid): Response
     {
@@ -176,9 +157,6 @@ class PostManagementController extends BaseController
 
     /**
      * Action - delete image of the post
-     * @param string|null $lang
-     * @param string $postUuid
-     * @return Response
      */
     public function deleteImage(?string $lang, string $postUuid): Response
     {

--- a/src/Module/Templates/DemoWeb/src/Controllers/PostManagementController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/PostManagementController.php.tpl
@@ -96,7 +96,7 @@ class PostManagementController extends BaseController
     /**
      * Action - display form for amend the post
      */
-    public function amendForm(Request $request,  ?string $lang, string $postUuid): Response
+    public function amendForm(Request $request, ?string $lang, string $postUuid): Response
     {
         $ref = $request->get('ref', 'posts');
 

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Activate.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Activate.php.tpl
@@ -30,18 +30,16 @@ class Activate extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         $token = (string)route_param('token');
 
         $request->set('token', $token);
 
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 
@@ -66,8 +64,8 @@ class Activate extends BaseMiddleware
     /**
      * @inheritDoc
      */
-    protected function respondWithError(Request $request, Response $response, $message): Response
+    protected function respondWithError(Request $request, $message): Response
     {
-        return $response->html(partial('errors/404'), StatusCode::NOT_FOUND);
+        return response()->html(partial('errors/404'), StatusCode::NOT_FOUND);
     }
 }

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Activate.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Activate.php.tpl
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -27,12 +27,6 @@ use Closure;
  */
 class Activate extends BaseMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         $token = (string)route_param('token');

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Auth.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Auth.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Auth.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Auth.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -25,12 +25,6 @@ use Closure;
  */
 class Auth extends QtMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if (!auth()->check()) {

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Auth.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Auth.php.tpl
@@ -28,7 +28,6 @@ class Auth extends QtMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */

--- a/src/Module/Templates/DemoWeb/src/Middlewares/BaseMiddleware.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/BaseMiddleware.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoWeb/src/Middlewares/BaseMiddleware.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/BaseMiddleware.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.9
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -25,15 +25,10 @@ use Quantum\Http\Request;
  */
 abstract class BaseMiddleware extends QtMiddleware
 {
-
-    /**
-     * @var Validator
-     */
     protected $validator;
 
     /**
      * Initialize Validator and define rules.
-     * @param Request $request
      */
     public function __construct(Request $request)
     {
@@ -43,7 +38,6 @@ abstract class BaseMiddleware extends QtMiddleware
     }
 
     /**
-     * @param Request $request
      * @return Response|null
      */
     protected function validateRequest(Request $request): ?Response
@@ -57,7 +51,6 @@ abstract class BaseMiddleware extends QtMiddleware
 
     /**
      * Define validation rules specific to middleware.
-     * @param Request $request
      */
     protected function defineValidationRules(Request $request)
     {
@@ -66,9 +59,6 @@ abstract class BaseMiddleware extends QtMiddleware
 
     /**
      * Handles error response logic.
-     * @param Request $request
-     * @param mixed $message
-     * @return Response
      */
     protected function respondWithError(Request $request, $message): Response
     {

--- a/src/Module/Templates/DemoWeb/src/Middlewares/BaseMiddleware.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/BaseMiddleware.php.tpl
@@ -44,13 +44,12 @@ abstract class BaseMiddleware extends QtMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @return Response|null
      */
-    protected function validateRequest(Request $request, Response $response): ?Response
+    protected function validateRequest(Request $request): ?Response
     {
         if (!$this->validator->isValid($request->all())) {
-            return $this->respondWithError($request, $response, $this->validator->getErrors());
+            return $this->respondWithError($request, $this->validator->getErrors());
         }
 
         return null;
@@ -68,13 +67,12 @@ abstract class BaseMiddleware extends QtMiddleware
     /**
      * Handles error response logic.
      * @param Request $request
-     * @param Response $response
      * @param mixed $message
      * @return Response
      */
-    protected function respondWithError(Request $request, Response $response, $message): Response
+    protected function respondWithError(Request $request, $message): Response
     {
         // default no-op: subclasses override if needed
-        return $response;
+        return response();
     }
 }

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Comment.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Comment.php.tpl
@@ -28,13 +28,11 @@ class Comment extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 
@@ -58,9 +56,7 @@ class Comment extends BaseMiddleware
     /**
      * @inheritDoc
      */
-    protected function respondWithError(
-        Request $request,
-        Response $response,
+    protected function respondWithError(Request $request,
         $message
     ): Response
     {

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Comment.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Comment.php.tpl
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.9
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -25,11 +25,6 @@ use Closure;
  */
 class Comment extends BaseMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if ($errorResponse = $this->validateRequest($request)) {

--- a/src/Module/Templates/DemoWeb/src/Middlewares/CommentOwner.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/CommentOwner.php.tpl
@@ -29,18 +29,16 @@ class CommentOwner extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         $uuid = (string)route_param('uuid');
 
         $request->set('uuid', $uuid);
 
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 

--- a/src/Module/Templates/DemoWeb/src/Middlewares/CommentOwner.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/CommentOwner.php.tpl
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.9
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -26,12 +26,6 @@ use Closure;
  */
 class CommentOwner extends BaseMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         $uuid = (string)route_param('uuid');

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Editor.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Editor.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Editor.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Editor.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -41,11 +41,6 @@ class Editor extends BaseMiddleware
      */
     private const ALLOWED_IMAGE_EXTENSIONS = ['jpeg', 'jpg', 'png'];
 
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if (!in_array(auth()->user()->role, self::ROLES)) {

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Editor.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Editor.php.tpl
@@ -43,19 +43,17 @@ class Editor extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         if (!in_array(auth()->user()->role, self::ROLES)) {
             return redirect(base_url(true) . '/' . current_lang());
         }
 
         if ($request->isMethod('post') || $request->isMethod('put')) {
-            if ($errorResponse = $this->validateRequest($request, $response)) {
+            if ($errorResponse = $this->validateRequest($request)) {
                 return $errorResponse;
             }
         }
@@ -94,7 +92,7 @@ class Editor extends BaseMiddleware
     /**
      * @inheritDoc
      */
-    protected function respondWithError(Request $request, Response $response, $message): Response
+    protected function respondWithError(Request $request, $message): Response
     {
         $data = $request->all();
 

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Forget.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Forget.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Forget.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Forget.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -26,13 +26,6 @@ use Closure;
  */
 class Forget extends BaseMiddleware
 {
-
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if ($request->isMethod('post')) {
@@ -46,7 +39,6 @@ class Forget extends BaseMiddleware
 
     /**
      * Define validation rules
-     * @param Request $request
      */
     protected function defineValidationRules(Request $request)
     {

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Forget.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Forget.php.tpl
@@ -30,15 +30,13 @@ class Forget extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         if ($request->isMethod('post')) {
-            if ($errorResponse = $this->validateRequest($request, $response)) {
+            if ($errorResponse = $this->validateRequest($request)) {
                 return $errorResponse;
             }
         }
@@ -64,9 +62,7 @@ class Forget extends BaseMiddleware
     /**
      * @inheritDoc
      */
-    protected function respondWithError(
-        Request $request,
-        Response $response,
+    protected function respondWithError(Request $request,
         $message
     ): Response
     {

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Guest.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Guest.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Guest.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Guest.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -25,12 +25,6 @@ use Closure;
  */
 class Guest extends QtMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if (auth()->check()) {

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Guest.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Guest.php.tpl
@@ -28,7 +28,6 @@ class Guest extends QtMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Password.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Password.php.tpl
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.9
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -27,12 +27,6 @@ use Closure;
  */
 class Password extends BaseMiddleware
 {
-
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if ($request->isMethod('post')) {

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Password.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Password.php.tpl
@@ -31,14 +31,12 @@ class Password extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         if ($request->isMethod('post')) {
-            $this->validateRequest($request, $response);
+            $this->validateRequest($request);
         }
 
         return $next($request);
@@ -70,7 +68,7 @@ class Password extends BaseMiddleware
     /**
      * @inheritDoc
      */
-    protected function respondWithError(Request $request, Response $response, $message)
+    protected function respondWithError(Request $request, $message)
     {
         session()->setFlash('error', $message);
         redirectWith(base_url(true) . '/' . current_lang() . '/account-settings#account_password', $request->all());

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Password.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Password.php.tpl
@@ -30,7 +30,9 @@ class Password extends BaseMiddleware
     public function apply(Request $request, Closure $next): Response
     {
         if ($request->isMethod('post')) {
-            $this->validateRequest($request);
+            if ($errorResponse = $this->validateRequest($request)) {
+                return $errorResponse;
+            }
         }
 
         return $next($request);

--- a/src/Module/Templates/DemoWeb/src/Middlewares/PostOwner.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/PostOwner.php.tpl
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.9
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -27,13 +27,6 @@ use Closure;
  */
 class PostOwner extends BaseMiddleware
 {
-
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         $uuid = (string)route_param('uuid');

--- a/src/Module/Templates/DemoWeb/src/Middlewares/PostOwner.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/PostOwner.php.tpl
@@ -31,18 +31,16 @@ class PostOwner extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         $uuid = (string)route_param('uuid');
 
         $request->set('uuid', $uuid);
 
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 
@@ -67,9 +65,9 @@ class PostOwner extends BaseMiddleware
     /**
      * @inheritDoc
      */
-    protected function respondWithError(Request $request, Response $response, $message = null): Response
+    protected function respondWithError(Request $request, $message = null): Response
     {
-        return $response->html(partial('errors/404'),  StatusCode::NOT_FOUND);
+        return response()->html(partial('errors/404'),  StatusCode::NOT_FOUND);
     }
 
     /**

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Resend.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Resend.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Resend.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Resend.php.tpl
@@ -29,18 +29,16 @@ class Resend extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         $code = (string) route_param('code');
 
         $request->set('code', $code);
 
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 
@@ -62,9 +60,7 @@ class Resend extends BaseMiddleware
     /**
      * @inheritDoc
      */
-    protected function respondWithError(
-        Request $request,
-        Response $response,
+    protected function respondWithError(Request $request,
         $message,
     ): Response {
         session()->setFlash('error', $message);

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Resend.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Resend.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -25,13 +25,6 @@ use Closure;
  */
 class Resend extends BaseMiddleware
 {
-
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         $code = (string) route_param('code');

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Reset.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Reset.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Reset.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Reset.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -27,12 +27,6 @@ use Closure;
  */
 class Reset extends BaseMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         $token = (string) route_param('token');

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Reset.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Reset.php.tpl
@@ -30,18 +30,16 @@ class Reset extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         $token = (string) route_param('token');
 
         $request->set('token', $token);
 
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 
@@ -80,10 +78,10 @@ class Reset extends BaseMiddleware
     /**
      * @inheritDoc
      */
-    protected function respondWithError(Request $request, Response $response, $message): Response
+    protected function respondWithError(Request $request, $message): Response
     {
         if ($request->isMethod('get') && isset($message['token'])) {
-            return $response->html(partial('errors/404'), StatusCode::NOT_FOUND);
+            return response()->html(partial('errors/404'), StatusCode::NOT_FOUND);
         }
 
         session()->setFlash('error', $message);

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Signup.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Signup.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Signup.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Signup.php.tpl
@@ -29,13 +29,11 @@ class Signup extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         if ($request->isMethod('post')) {
             $captchaName = captcha()->getName();
 
@@ -44,7 +42,7 @@ class Signup extends BaseMiddleware
                 $request->delete($captchaName . '-response');
             }
 
-            if ($errorResponse = $this->validateRequest($request, $response)) {
+            if ($errorResponse = $this->validateRequest($request)) {
                 return $errorResponse;
             }
 
@@ -85,7 +83,7 @@ class Signup extends BaseMiddleware
     /**
      * @inheritDoc
      */
-    protected function respondWithError(Request $request, Response $response, $message): Response
+    protected function respondWithError(Request $request, $message): Response
     {
         session()->setFlash('error', $message);
         return redirectWith(base_url(true) . '/' . current_lang() . '/signup', $request->all());

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Signup.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Signup.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -26,12 +26,6 @@ use Closure;
  */
 class Signup extends BaseMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if ($request->isMethod('post')) {

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Update.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Update.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Update.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Update.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -25,12 +25,6 @@ use Closure;
  */
 class Update extends BaseMiddleware
 {
-
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if ($request->isMethod('post')) {

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Update.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Update.php.tpl
@@ -29,14 +29,12 @@ class Update extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         if ($request->isMethod('post')) {
-            if ($errorResponse = $this->validateRequest($request, $response)) {
+            if ($errorResponse = $this->validateRequest($request)) {
                 return $errorResponse;
             }
         }
@@ -62,9 +60,7 @@ class Update extends BaseMiddleware
     /**
      * @inheritDoc
      */
-    protected function respondWithError(
-        Request $request,
-        Response $response,
+    protected function respondWithError(Request $request,
         $message
     ): Response
     {

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Verify.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Verify.php.tpl
@@ -9,7 +9,7 @@
  * @author Arman Ag. <arman.ag@softberg.org>
  * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
  * @link http://quantum.softberg.org/
- * @since 2.9.8
+ * @since 3.0.0
  */
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
@@ -27,12 +27,6 @@ use Closure;
  */
 class Verify extends BaseMiddleware
 {
-
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         $code = (string) route_param('code');

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Verify.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Verify.php.tpl
@@ -30,18 +30,16 @@ class Verify extends BaseMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         $code = (string) route_param('code');
 
         $request->set('code', $code);
 
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 
@@ -67,10 +65,10 @@ class Verify extends BaseMiddleware
     /**
      * @inheritDoc
      */
-    protected function respondWithError(Request $request, Response $response, $message): Response
+    protected function respondWithError(Request $request, $message): Response
     {
         if ($request->isMethod('get') && isset($message['code'])) {
-            return $response->html(partial('errors/404'), StatusCode::NOT_FOUND);
+            return response()->html(partial('errors/404'), StatusCode::NOT_FOUND);
         }
 
         session()->setFlash('error', $message);

--- a/src/Module/Templates/Toolkit/src/Controllers/BaseController.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Controllers/BaseController.php.tpl
@@ -39,14 +39,8 @@ class BaseController
      */
     protected const CURRENT_PAGE = 1;
 
-    /**
-     * @var View
-     */
     protected View $view;
 
-    /**
-     * Works before an action
-     */
     public function __before()
     {
         $this->view = ViewFactory::get();

--- a/src/Module/Templates/Toolkit/src/Controllers/DashboardController.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Controllers/DashboardController.php.tpl
@@ -28,14 +28,8 @@ use ReflectionException;
  */
 class DashboardController extends BaseController
 {
-    /**
-     * @var DashboardService
-     */
     public DashboardService $dashboardService;
 
-    /**
-     * Works before an action
-     */
     public function __before()
     {
         $this->dashboardService = service(DashboardService::class);
@@ -43,9 +37,6 @@ class DashboardController extends BaseController
         parent::__before();
     }
 
-    /**
-     * @param Request $request
-     */
     public function index(Request $request): Response
     {
         $this->view->setParams([

--- a/src/Module/Templates/Toolkit/src/Controllers/DashboardController.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Controllers/DashboardController.php.tpl
@@ -45,14 +45,13 @@ class DashboardController extends BaseController
 
     /**
      * @param Request $request
-     * @param Response $response
      */
-    public function index(Request $request, Response $response): Response
+    public function index(Request $request): Response
     {
         $this->view->setParams([
             'title' => 'Dashboard',
         ]);
 
-        return $response->html($this->view->render('pages/dashboard/index'));
+        return response()->html($this->view->render('pages/dashboard/index'));
     }
 }

--- a/src/Module/Templates/Toolkit/src/Controllers/DatabaseController.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Controllers/DatabaseController.php.tpl
@@ -41,10 +41,9 @@ class DatabaseController extends BaseController
     }
 
     /**
-     * @param Response $response
      * @return Response
      */
-    public function list(Response $response): Response
+    public function list(): Response
     {
         $tables = $this->databaseService->getTables();
 
@@ -53,15 +52,14 @@ class DatabaseController extends BaseController
             'tables' => $tables,
         ]);
 
-        return $response->html($this->view->render('pages/database/index'));
+        return response()->html($this->view->render('pages/database/index'));
     }
 
     /**
      * @param Request $request
-     * @param Response $response
      * @throws DatabaseException
      */
-    public function single(Request $request, Response $response): Response
+    public function single(Request $request): Response
     {
         $tableName = $request->get('table');
         $perPage = $request->get('per_page', self::ITEMS_PER_PAGE);
@@ -79,7 +77,7 @@ class DatabaseController extends BaseController
             'pagination' => $tableData['pagination'],
         ]);
 
-        return $response->html($this->view->render('pages/database/table'));
+        return response()->html($this->view->render('pages/database/table'));
     }
 
     /**

--- a/src/Module/Templates/Toolkit/src/Controllers/DatabaseController.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Controllers/DatabaseController.php.tpl
@@ -25,9 +25,6 @@ use Quantum\Http\Request;
  */
 class DatabaseController extends BaseController
 {
-    /**
-     * @var DatabaseService
-     */
     private DatabaseService $databaseService;
 
     /**
@@ -40,9 +37,6 @@ class DatabaseController extends BaseController
         parent::__before();
     }
 
-    /**
-     * @return Response
-     */
     public function list(): Response
     {
         $tables = $this->databaseService->getTables();
@@ -56,7 +50,6 @@ class DatabaseController extends BaseController
     }
 
     /**
-     * @param Request $request
      * @throws DatabaseException
      */
     public function single(Request $request): Response
@@ -80,10 +73,6 @@ class DatabaseController extends BaseController
         return response()->html($this->view->render('pages/database/table'));
     }
 
-    /**
-     * @param Request $request
-     * @return Response
-     */
     public function create(Request $request): Response
     {
         $tableName = $request->get('table');
@@ -95,10 +84,6 @@ class DatabaseController extends BaseController
         return redirect(get_referrer() ?? base_url());
     }
 
-    /**
-     * @param Request $request
-     * @return Response
-     */
     public function update(Request $request): Response
     {
         $tableName = $request->get('table');
@@ -110,10 +95,6 @@ class DatabaseController extends BaseController
         return redirect(base_url(true) . '/database/view?table=' . $tableName);
     }
 
-    /**
-     * @param Request $request
-     * @return Response
-     */
     public function delete(Request $request): Response
     {
         $tableName = $request->get('tableName');

--- a/src/Module/Templates/Toolkit/src/Controllers/EmailsController.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Controllers/EmailsController.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/Toolkit/src/Controllers/EmailsController.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Controllers/EmailsController.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -28,14 +28,8 @@ use ReflectionException;
  */
 class EmailsController extends BaseController
 {
-    /**
-     * @var EmailService
-     */
     public EmailService $emailService;
 
-    /**
-     * Works before an action
-     */
     public function __before()
     {
         $this->emailService = service(EmailService::class);
@@ -43,9 +37,6 @@ class EmailsController extends BaseController
         parent::__before();
     }
 
-    /**
-     * @param Request $request
-     */
     public function list(Request $request): Response
     {
         $perPage = $request->get('per_page', self::ITEMS_PER_PAGE);
@@ -62,9 +53,6 @@ class EmailsController extends BaseController
         return response()->html($this->view->render('pages/email/index'));
     }
 
-    /**
-     * @param string $emailId
-     */
     public function single(string $emailId): Response
     {
         $email = $this->emailService->getEmail($emailId);
@@ -72,9 +60,6 @@ class EmailsController extends BaseController
         return response()->html(quoted_printable_decode($email->getParsedBody()));
     }
 
-    /**
-     * @param string $emailId
-     */
     public function delete(string $emailId): Response
     {
         $this->emailService->deleteEmail($emailId);

--- a/src/Module/Templates/Toolkit/src/Controllers/EmailsController.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Controllers/EmailsController.php.tpl
@@ -45,9 +45,8 @@ class EmailsController extends BaseController
 
     /**
      * @param Request $request
-     * @param Response $response
      */
-    public function list(Request $request, Response $response): Response
+    public function list(Request $request): Response
     {
         $perPage = $request->get('per_page', self::ITEMS_PER_PAGE);
         $currentPage = $request->get('page', self::CURRENT_PAGE);
@@ -60,18 +59,17 @@ class EmailsController extends BaseController
             'pagination' => $data
         ]);
 
-        return $response->html($this->view->render('pages/email/index'));
+        return response()->html($this->view->render('pages/email/index'));
     }
 
     /**
-     * @param Response $response
      * @param string $emailId
      */
-    public function single(Response $response, string $emailId): Response
+    public function single(string $emailId): Response
     {
         $email = $this->emailService->getEmail($emailId);
 
-        return $response->html(quoted_printable_decode($email->getParsedBody()));
+        return response()->html(quoted_printable_decode($email->getParsedBody()));
     }
 
     /**

--- a/src/Module/Templates/Toolkit/src/Controllers/LogsController.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Controllers/LogsController.php.tpl
@@ -44,9 +44,8 @@ class LogsController extends BaseController
     }
 
     /**
-     * @param Response $response
      */
-    public function list(Response $response): Response
+    public function list(): Response
     {
         $filteredLogFiles = $this->logsService->getLogFiles();
 
@@ -55,14 +54,13 @@ class LogsController extends BaseController
             'logFiles' => $filteredLogFiles,
         ]);
 
-        return $response->html($this->view->render('pages/logs/index'));
+        return response()->html($this->view->render('pages/logs/index'));
     }
 
     /**
      * @param Request $request
-     * @param Response $response
      */
-    public function single(Request $request, Response $response): Response
+    public function single(Request $request): Response
     {
         $logFile = $request->get('logFile');
         $perPage = $request->get('per_page', self::ITEMS_PER_PAGE);
@@ -78,6 +76,6 @@ class LogsController extends BaseController
             'pagination' => $parsedLogs,
         ]);
 
-        return $response->html($this->view->render('pages/logs/log'));
+        return response()->html($this->view->render('pages/logs/log'));
     }
 }

--- a/src/Module/Templates/Toolkit/src/Controllers/LogsController.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Controllers/LogsController.php.tpl
@@ -28,14 +28,8 @@ use ReflectionException;
  */
 class LogsController extends BaseController
 {
-    /**
-     * @var LogsService
-     */
     public LogsService $logsService;
 
-    /**
-     * Works before an action
-     */
     public function __before()
     {
         $this->logsService = service(LogsService::class);
@@ -43,8 +37,6 @@ class LogsController extends BaseController
         parent::__before();
     }
 
-    /**
-     */
     public function list(): Response
     {
         $filteredLogFiles = $this->logsService->getLogFiles();
@@ -57,9 +49,6 @@ class LogsController extends BaseController
         return response()->html($this->view->render('pages/logs/index'));
     }
 
-    /**
-     * @param Request $request
-     */
     public function single(Request $request): Response
     {
         $logFile = $request->get('logFile');

--- a/src/Module/Templates/Toolkit/src/Middlewares/BaseMiddleware.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Middlewares/BaseMiddleware.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/Toolkit/src/Middlewares/BaseMiddleware.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Middlewares/BaseMiddleware.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -25,14 +25,10 @@ use Quantum\Http\Request;
  */
 abstract class BaseMiddleware extends QtMiddleware
 {
-    /**
-     * @var Validator
-     */
     protected Validator $validator;
 
     /**
      * Initialize Validator and define rules.
-     * @param Request $request
      */
     public function __construct(Request $request)
     {
@@ -41,9 +37,6 @@ abstract class BaseMiddleware extends QtMiddleware
         $this->defineValidationRules($request);
     }
 
-    /**
-     * @param Request $request
-     */
     protected function validateRequest(Request $request)
     {
         if (!$this->validator->isValid($request->all())) {
@@ -53,7 +46,6 @@ abstract class BaseMiddleware extends QtMiddleware
 
     /**
      * Define validation rules specific to middleware.
-     * @param Request $request
      */
     protected function defineValidationRules(Request $request)
     {
@@ -62,8 +54,6 @@ abstract class BaseMiddleware extends QtMiddleware
 
     /**
      * Handles error response logic.
-     * @param Request $request
-     * @param mixed $message
      */
     protected function respondWithError(Request $request, $message)
     {

--- a/src/Module/Templates/Toolkit/src/Middlewares/BaseMiddleware.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Middlewares/BaseMiddleware.php.tpl
@@ -43,12 +43,11 @@ abstract class BaseMiddleware extends QtMiddleware
 
     /**
      * @param Request $request
-     * @param Response $response
      */
-    protected function validateRequest(Request $request, Response $response)
+    protected function validateRequest(Request $request)
     {
         if (!$this->validator->isValid($request->all())) {
-            $this->respondWithError($request, $response, $this->validator->getErrors());
+            $this->respondWithError($request, $this->validator->getErrors());
         }
     }
 
@@ -64,10 +63,9 @@ abstract class BaseMiddleware extends QtMiddleware
     /**
      * Handles error response logic.
      * @param Request $request
-     * @param Response $response
      * @param mixed $message
      */
-    protected function respondWithError(Request $request, Response $response, $message)
+    protected function respondWithError(Request $request, $message)
     {
         // default no-op: subclasses override if needed
     }

--- a/src/Module/Templates/Toolkit/src/Middlewares/BaseMiddleware.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Middlewares/BaseMiddleware.php.tpl
@@ -40,7 +40,7 @@ abstract class BaseMiddleware extends QtMiddleware
     protected function validateRequest(Request $request)
     {
         if (!$this->validator->isValid($request->all())) {
-            $this->respondWithError($request, $this->validator->getErrors());
+            return $this->respondWithError($request, $this->validator->getErrors());
         }
     }
 

--- a/src/Module/Templates/Toolkit/src/Middlewares/BaseMiddleware.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Middlewares/BaseMiddleware.php.tpl
@@ -14,8 +14,8 @@
 
 namespace Modules\Toolkit\Middlewares;
 
-use Quantum\Validation\Validator;
 use Quantum\Middleware\QtMiddleware;
+use Quantum\Validation\Validator;
 use Quantum\Http\Response;
 use Quantum\Http\Request;
 
@@ -37,11 +37,13 @@ abstract class BaseMiddleware extends QtMiddleware
         $this->defineValidationRules($request);
     }
 
-    protected function validateRequest(Request $request)
+    protected function validateRequest(Request $request): ?Response
     {
         if (!$this->validator->isValid($request->all())) {
             return $this->respondWithError($request, $this->validator->getErrors());
         }
+
+        return null;
     }
 
     /**
@@ -55,8 +57,5 @@ abstract class BaseMiddleware extends QtMiddleware
     /**
      * Handles error response logic.
      */
-    protected function respondWithError(Request $request, $message)
-    {
-        // default no-op: subclasses override if needed
-    }
+    abstract protected function respondWithError(Request $request, $message): Response;
 }

--- a/src/Module/Templates/Toolkit/src/Middlewares/BasicAuth.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Middlewares/BasicAuth.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/Toolkit/src/Middlewares/BasicAuth.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Middlewares/BasicAuth.php.tpl
@@ -51,8 +51,8 @@ class BasicAuth extends QtMiddleware
 
     private function unauthorizedResponse(): Response
     {
-        $response = response();
-        $response->setHeader('WWW-Authenticate', 'Basic realm="Quantum Toolkit"');
-        return $response->html(partial('errors' . DS . '401'), 401);
+        return response()
+            ->setHeader('WWW-Authenticate', 'Basic realm="Quantum Toolkit"')
+            ->html(partial('errors' . DS . '401'), 401);
     }
 }

--- a/src/Module/Templates/Toolkit/src/Middlewares/BasicAuth.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Middlewares/BasicAuth.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -26,11 +26,6 @@ use Closure;
  */
 class BasicAuth extends QtMiddleware
 {
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         $userCredentials = $request->getBasicAuthCredentials();
@@ -42,10 +37,6 @@ class BasicAuth extends QtMiddleware
         return $next($request);
     }
 
-    /**
-     * @param array $credentials
-     * @return bool
-     */
     private function isValidCredentials(array $credentials): bool
     {
         if (!config()->has('basic_auth')) {
@@ -58,9 +49,6 @@ class BasicAuth extends QtMiddleware
             && $credentials['password'] === $configCredentials['password'];
     }
 
-    /**
-     * @return Response
-     */
     private function unauthorizedResponse(): Response
     {
         $response = response();

--- a/src/Module/Templates/Toolkit/src/Middlewares/BasicAuth.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Middlewares/BasicAuth.php.tpl
@@ -28,17 +28,15 @@ class BasicAuth extends QtMiddleware
 {
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
         $userCredentials = $request->getBasicAuthCredentials();
 
         if (!$userCredentials || !$this->isValidCredentials($userCredentials)) {
-            return $this->unauthorizedResponse($response);
+            return $this->unauthorizedResponse();
         }
 
         return $next($request);
@@ -61,11 +59,11 @@ class BasicAuth extends QtMiddleware
     }
 
     /**
-     * @param Response $response
      * @return Response
      */
-    private function unauthorizedResponse(Response $response): Response
+    private function unauthorizedResponse(): Response
     {
+        $response = response();
         $response->setHeader('WWW-Authenticate', 'Basic realm="Quantum Toolkit"');
         return $response->html(partial('errors' . DS . '401'), 401);
     }

--- a/src/Module/Templates/Toolkit/src/Middlewares/CreateTable.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Middlewares/CreateTable.php.tpl
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Quantum PHP Framework

--- a/src/Module/Templates/Toolkit/src/Middlewares/CreateTable.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Middlewares/CreateTable.php.tpl
@@ -29,14 +29,12 @@ class CreateTable extends BaseMiddleware
 {
     /**
      * @param Request $request
-     * @param Response $response
      * @param Closure $next
      * @return Response
      */
     public function apply(Request $request, Closure $next): Response
     {
-        $response = response();
-        if ($errorResponse = $this->validateRequest($request, $response)) {
+        if ($errorResponse = $this->validateRequest($request)) {
             return $errorResponse;
         }
 
@@ -68,7 +66,7 @@ class CreateTable extends BaseMiddleware
     /**
      * @inheritDoc
      */
-    protected function respondWithError(Request $request, Response $response, $message): Response
+    protected function respondWithError(Request $request, $message): Response
     {
         session()->setFlash('error', $message);
         return redirect(get_referrer() ?? base_url());

--- a/src/Module/Templates/Toolkit/src/Middlewares/CreateTable.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Middlewares/CreateTable.php.tpl
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 /**
  * Quantum PHP Framework
@@ -27,11 +27,6 @@ use Closure;
  */
 class CreateTable extends BaseMiddleware
 {
-    /**
-     * @param Request $request
-     * @param Closure $next
-     * @return Response
-     */
     public function apply(Request $request, Closure $next): Response
     {
         if ($errorResponse = $this->validateRequest($request)) {


### PR DESCRIPTION
Closes #496 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Controllers and middleware no longer require an injected Response parameter; responses are produced via a global response() helper. Method signatures and docblocks were simplified to reduce boilerplate and preserve existing behavior and payloads.

* **Chores**
  * Template metadata updated to reflect version 3.0.0 and assorted PHPDoc/comment cleanups across templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->