### PR TITLE
Issue/500 qt prefix class rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - **BREAKING:** Renamed `Quantum\\Service\\QtService` to `Quantum\\Service\\Service` (#500)
 - **BREAKING:** Renamed `Quantum\\Middleware\\QtMiddleware` to `Quantum\\Middleware\\Middleware` (#500)
 - **BREAKING:** Renamed `Quantum\\Migration\\QtMigration` to `Quantum\\Migration\\Migration` (#500)
+- **BREAKING:** Renamed `Quantum\\Console\\QtCommand` to `Quantum\\Console\\CliCommand` (#500)
 
 - **BREAKING:** Minimum PHP version requirement raised from 7.3 to 7.4
 - Modernized codebase with PHP 7.4+ syntax using Rector:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   - `env()` helper now delegates through `environment()->getValue()`
 - **BREAKING:** Renamed `Quantum\\Service\\QtService` to `Quantum\\Service\\Service` (#500)
 - **BREAKING:** Renamed `Quantum\\Middleware\\QtMiddleware` to `Quantum\\Middleware\\Middleware` (#500)
+- **BREAKING:** Renamed `Quantum\\Migration\\QtMigration` to `Quantum\\Migration\\Migration` (#500)
 
 - **BREAKING:** Minimum PHP version requirement raised from 7.3 to 7.4
 - Modernized codebase with PHP 7.4+ syntax using Rector:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Uses `Dotenv::createArrayBacked()` for isolated, deterministic env loading
   - New `environment()` helper function and shorthand check methods: `isProduction()`, `isTesting()`, `isStaging()`, `isDevelopment()`, `isLocal()`
   - `env()` helper now delegates through `environment()->getValue()`
+- **BREAKING:** Renamed `Quantum\\Service\\QtService` to `Quantum\\Service\\Service` (#500)
 
 - **BREAKING:** Minimum PHP version requirement raised from 7.3 to 7.4
 - Modernized codebase with PHP 7.4+ syntax using Rector:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - New `environment()` helper function and shorthand check methods: `isProduction()`, `isTesting()`, `isStaging()`, `isDevelopment()`, `isLocal()`
   - `env()` helper now delegates through `environment()->getValue()`
 - **BREAKING:** Renamed `Quantum\\Service\\QtService` to `Quantum\\Service\\Service` (#500)
+- **BREAKING:** Renamed `Quantum\\Middleware\\QtMiddleware` to `Quantum\\Middleware\\Middleware` (#500)
 
 - **BREAKING:** Minimum PHP version requirement raised from 7.3 to 7.4
 - Modernized codebase with PHP 7.4+ syntax using Rector:

--- a/src/Auth/Factories/AuthFactory.php
+++ b/src/Auth/Factories/AuthFactory.php
@@ -27,7 +27,7 @@ use Quantum\App\Exceptions\BaseException;
 use Quantum\Auth\Adapters\JwtAuthAdapter;
 use Quantum\Di\Exceptions\DiException;
 use Quantum\Auth\Enums\AuthType;
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 use Quantum\Hasher\Hasher;
 use Quantum\Jwt\JwtToken;
 use Quantum\Loader\Setup;
@@ -126,7 +126,7 @@ class AuthFactory
     {
         $authServiceClass = config()->get('auth.' . $adapter . '.service');
 
-        /** @var class-string<QtService> $authServiceClass */
+        /** @var class-string<Service> $authServiceClass */
         $authService = ServiceFactory::create($authServiceClass);
 
         if (!$authService instanceof AuthServiceInterface) {

--- a/src/Console/CliCommand.php
+++ b/src/Console/CliCommand.php
@@ -26,10 +26,10 @@ use Symfony\Component\Console\Command\Command;
 use RuntimeException;
 
 /**
- * Class QtCommand
+ * Class CliCommand
  * @package Quantum\Console
  */
-abstract class QtCommand extends Command implements CommandInterface
+abstract class CliCommand extends Command implements CommandInterface
 {
     /**
      * Console command name
@@ -65,7 +65,7 @@ abstract class QtCommand extends Command implements CommandInterface
     protected ?OutputInterface $output = null;
 
     /**
-     * QtCommand constructor.
+     * CliCommand constructor.
      */
     public function __construct()
     {

--- a/src/Console/CommandDiscovery.php
+++ b/src/Console/CommandDiscovery.php
@@ -42,7 +42,7 @@ class CommandDiscovery
 
             $commandReflection = new ReflectionClass($commandClass);
 
-            if (!$commandReflection->isInstantiable() || !$commandReflection->isSubclassOf(QtCommand::class)) {
+            if (!$commandReflection->isInstantiable() || !$commandReflection->isSubclassOf(CliCommand::class)) {
                 continue;
             }
 

--- a/src/Console/Commands/CronRunCommand.php
+++ b/src/Console/Commands/CronRunCommand.php
@@ -20,7 +20,7 @@ use Quantum\Config\Exceptions\ConfigException;
 use Quantum\Cron\Exceptions\CronException;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Di\Exceptions\DiException;
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 use Quantum\Cron\CronManager;
 use ReflectionException;
 use Throwable;
@@ -29,7 +29,7 @@ use Throwable;
  * Class CronRunCommand
  * @package Quantum\Console
  */
-class CronRunCommand extends QtCommand
+class CronRunCommand extends CliCommand
 {
     /**
      * The console command name.

--- a/src/Console/Commands/DebugBarCommand.php
+++ b/src/Console/Commands/DebugBarCommand.php
@@ -20,14 +20,14 @@ use Quantum\Storage\Exceptions\FileSystemException;
 use Quantum\Storage\Factories\FileSystemFactory;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Storage\FileSystem;
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 use ReflectionException;
 
 /**
  * Class DebugBarAssetsCommand
  * @package Quantum\Console
  */
-class DebugBarCommand extends QtCommand
+class DebugBarCommand extends CliCommand
 {
     /**
      * File System

--- a/src/Console/Commands/EnvCommand.php
+++ b/src/Console/Commands/EnvCommand.php
@@ -20,7 +20,7 @@ use Quantum\Storage\Factories\FileSystemFactory;
 use Quantum\Config\Exceptions\ConfigException;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Di\Exceptions\DiException;
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 use ReflectionException;
 use Quantum\App\App;
 
@@ -28,7 +28,7 @@ use Quantum\App\App;
  * Class EnvCommand
  * @package Quantum\Console
  */
-class EnvCommand extends QtCommand
+class EnvCommand extends CliCommand
 {
     /**
      * Command name

--- a/src/Console/Commands/InstallToolkitCommand.php
+++ b/src/Console/Commands/InstallToolkitCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Quantum\Config\Exceptions\ConfigException;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Di\Exceptions\DiException;
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 use ReflectionException;
 use RuntimeException;
 
@@ -31,7 +31,7 @@ use RuntimeException;
  * Class InstallToolkitCommand
  * @package Quantum\Console
  */
-class InstallToolkitCommand extends QtCommand
+class InstallToolkitCommand extends CliCommand
 {
     /**
      * Command name

--- a/src/Console/Commands/KeyGenerateCommand.php
+++ b/src/Console/Commands/KeyGenerateCommand.php
@@ -17,14 +17,14 @@ declare(strict_types=1);
 namespace Quantum\Console\Commands;
 
 use Quantum\Environment\Exceptions\EnvException;
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 use Exception;
 
 /**
  * Class KeyGenerateCommand
  * @package Quantum\Console
  */
-class KeyGenerateCommand extends QtCommand
+class KeyGenerateCommand extends CliCommand
 {
     /**
      * Command name

--- a/src/Console/Commands/MigrationGenerateCommand.php
+++ b/src/Console/Commands/MigrationGenerateCommand.php
@@ -18,13 +18,13 @@ namespace Quantum\Console\Commands;
 
 use Quantum\Migration\Exceptions\MigrationException;
 use Quantum\Migration\MigrationManager;
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 
 /**
  * Class MigrationGenerateCommand
  * @package Quantum\Console
  */
-class MigrationGenerateCommand extends QtCommand
+class MigrationGenerateCommand extends CliCommand
 {
     /**
      * The console command name.

--- a/src/Console/Commands/MigrationMigrateCommand.php
+++ b/src/Console/Commands/MigrationMigrateCommand.php
@@ -20,13 +20,13 @@ use Quantum\Migration\Exceptions\MigrationException;
 use Quantum\Database\Exceptions\DatabaseException;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Migration\MigrationManager;
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 
 /**
  * Class MigrationMigrateCommand
  * @package Quantum\Console
  */
-class MigrationMigrateCommand extends QtCommand
+class MigrationMigrateCommand extends CliCommand
 {
     /**
      * The console command name.

--- a/src/Console/Commands/ModuleGenerateCommand.php
+++ b/src/Console/Commands/ModuleGenerateCommand.php
@@ -18,14 +18,14 @@ namespace Quantum\Console\Commands;
 
 use Symfony\Component\VarExporter\Exception\ExceptionInterface;
 use Quantum\Module\ModuleManager;
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 use Exception;
 
 /**
  * Class ModuleGenerateCommand
  * @package Quantum\Console\Commands
  */
-class ModuleGenerateCommand extends QtCommand
+class ModuleGenerateCommand extends CliCommand
 {
     /**
      * Command name

--- a/src/Console/Commands/OpenApiCommand.php
+++ b/src/Console/Commands/OpenApiCommand.php
@@ -25,7 +25,7 @@ use Quantum\Router\RouteCollection;
 use Quantum\Module\ModuleLoader;
 use Quantum\Router\RouteBuilder;
 use Quantum\Storage\FileSystem;
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 use ReflectionException;
 use OpenApi\Generator;
 use Quantum\Di\Di;
@@ -34,7 +34,7 @@ use Quantum\Di\Di;
  * Class OpenApiUiAssetsCommand
  * @package Quantum\Console
  */
-class OpenApiCommand extends QtCommand
+class OpenApiCommand extends CliCommand
 {
     /**
      * File System

--- a/src/Console/Commands/ResourceCacheClearCommand.php
+++ b/src/Console/Commands/ResourceCacheClearCommand.php
@@ -22,7 +22,7 @@ use Quantum\Config\Exceptions\ConfigException;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Di\Exceptions\DiException;
 use Quantum\Storage\FileSystem;
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 use Quantum\Loader\Setup;
 use ReflectionException;
 use Exception;
@@ -31,7 +31,7 @@ use Exception;
  * Class ResourceCacheClearCommand
  * @package Quantum\Console
  */
-class ResourceCacheClearCommand extends QtCommand
+class ResourceCacheClearCommand extends CliCommand
 {
     /**
      * Command name

--- a/src/Console/Commands/RouteListCommand.php
+++ b/src/Console/Commands/RouteListCommand.php
@@ -23,7 +23,7 @@ use Quantum\Di\Exceptions\DiException;
 use Quantum\Router\RouteCollection;
 use Quantum\Router\RouteBuilder;
 use Quantum\Module\ModuleLoader;
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 use Quantum\Router\Route;
 use ReflectionException;
 use Quantum\Di\Di;
@@ -32,7 +32,7 @@ use Quantum\Di\Di;
  * Class RouteListCommand
  * @package Quantum\Console
  */
-class RouteListCommand extends QtCommand
+class RouteListCommand extends CliCommand
 {
     /**
      * The console command name.

--- a/src/Console/Commands/ServeCommand.php
+++ b/src/Console/Commands/ServeCommand.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace Quantum\Console\Commands;
 
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 use RuntimeException;
 use Throwable;
 
@@ -24,7 +24,7 @@ use Throwable;
  * Class ServeCommand
  * @package Quantum\Console
  */
-class ServeCommand extends QtCommand
+class ServeCommand extends CliCommand
 {
     /**
      * Platform Windows

--- a/src/Console/Commands/VersionCommand.php
+++ b/src/Console/Commands/VersionCommand.php
@@ -16,14 +16,14 @@ declare(strict_types=1);
 
 namespace Quantum\Console\Commands;
 
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 use Povils\Figlet\Figlet;
 
 /**
  * Class VersionCommand
  * @package Quantum\Console
  */
-class VersionCommand extends QtCommand
+class VersionCommand extends CliCommand
 {
     /**
      * Command name

--- a/src/Middleware/Middleware.php
+++ b/src/Middleware/Middleware.php
@@ -21,10 +21,10 @@ use Quantum\Http\Request;
 use Closure;
 
 /**
- * Class QtMiddleware
+ * Class Middleware
  * @package Quantum\Middleware
  */
-abstract class QtMiddleware
+abstract class Middleware
 {
     /**
      * Applies the middleware

--- a/src/Middleware/MiddlewareManager.php
+++ b/src/Middleware/MiddlewareManager.php
@@ -67,9 +67,9 @@ class MiddlewareManager
 
     /**
      * Loads and gets the current middleware instance
-     * @throws MiddlewareException|BaseException|ReflectionException
+     * @throws MiddlewareException|BaseException
      */
-    private function getMiddleware(Request $request): QtMiddleware
+    private function getMiddleware(Request $request): Middleware
     {
         $middlewareClass = request()->getModuleBaseNamespace() . '\\' . $this->module . '\\Middlewares\\' . current($this->middlewares);
 
@@ -79,8 +79,8 @@ class MiddlewareManager
 
         $middleware = new $middlewareClass($request);
 
-        if (!$middleware instanceof QtMiddleware) {
-            throw MiddlewareException::notInstanceOf($middlewareClass, QtMiddleware::class);
+        if (!$middleware instanceof Middleware) {
+            throw MiddlewareException::notInstanceOf($middlewareClass, Middleware::class);
         }
 
         return $middleware;

--- a/src/Migration/Enums/ExceptionMessages.php
+++ b/src/Migration/Enums/ExceptionMessages.php
@@ -30,5 +30,5 @@ final class ExceptionMessages extends BaseExceptionMessages
 
     public const NOTHING_TO_MIGRATE = 'Nothing to migrate';
 
-    public const INVALID_MIGRATION_CLASS = 'Migration class `{%1}` must extend QtMigration';
+    public const INVALID_MIGRATION_CLASS = 'Migration class `{%1}` must extend Migration';
 }

--- a/src/Migration/Migration.php
+++ b/src/Migration/Migration.php
@@ -19,10 +19,10 @@ namespace Quantum\Migration;
 use Quantum\Database\Factories\TableFactory;
 
 /**
- * Class QtMigration
+ * Class Migration
  * @package Quantum\Migration
  */
-abstract class QtMigration
+abstract class Migration
 {
     /**
      * Upgrades with the specified migration class

--- a/src/Migration/MigrationManager.php
+++ b/src/Migration/MigrationManager.php
@@ -158,7 +158,7 @@ class MigrationManager
 
             $migration = new $migrationClassName();
 
-            if (!$migration instanceof QtMigration) {
+            if (!$migration instanceof Migration) {
                 throw MigrationException::invalidMigrationClass($migrationClassName);
             }
 
@@ -195,7 +195,7 @@ class MigrationManager
 
             $migration = new $migrationClassName();
 
-            if (!$migration instanceof QtMigration) {
+            if (!$migration instanceof Migration) {
                 throw MigrationException::invalidMigrationClass($migrationClassName);
             }
 

--- a/src/Migration/MigrationTable.php
+++ b/src/Migration/MigrationTable.php
@@ -24,7 +24,7 @@ use Quantum\Database\Enums\Type;
  * Class MigrationTable
  * @package Quantum\Migration
  */
-class MigrationTable extends QtMigration
+class MigrationTable extends Migration
 {
     /**
      * Migrations table name

--- a/src/Migration/Templates/MigrationTemplate.php
+++ b/src/Migration/Templates/MigrationTemplate.php
@@ -30,9 +30,10 @@ class MigrationTemplate
         return '<?php
 
 use Quantum\Database\Factories\TableFactory;
+use Quantum\Migration\Migration;
 
 
-class ' . ucfirst($className) . ' extends QtMigration
+class ' . ucfirst($className) . ' extends Migration
 {
     
     public function up(?TableFactory $tableFactory) {
@@ -57,8 +58,9 @@ class ' . ucfirst($className) . ' extends QtMigration
         return '<?php
 
 use Quantum\Database\Factories\TableFactory;
+use Quantum\Migration\Migration;
 
-class ' . ucfirst($className) . ' extends QtMigration
+class ' . ucfirst($className) . ' extends Migration
 {
     
     public function up(?TableFactory $tableFactory) {
@@ -83,8 +85,9 @@ class ' . ucfirst($className) . ' extends QtMigration
         return '<?php
 
 use Quantum\Database\Factories\TableFactory;
+use Quantum\Migration\Migration;
 
-class ' . ucfirst($className) . ' extends QtMigration
+class ' . ucfirst($className) . ' extends Migration
 {
     
     public function up(?TableFactory $tableFactory) {
@@ -109,8 +112,9 @@ class ' . ucfirst($className) . ' extends QtMigration
         return '<?php
 
 use Quantum\Database\Factories\TableFactory;
+use Quantum\Migration\Migration;
 
-class ' . ucfirst($className) . ' extends QtMigration
+class ' . ucfirst($className) . ' extends Migration
 {
     
     public function up(?TableFactory $tableFactory) {

--- a/src/Module/Templates/DemoApi/src/Middlewares/BaseMiddleware.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/BaseMiddleware.php.tpl
@@ -16,7 +16,7 @@ namespace {{MODULE_NAMESPACE}}\Middlewares;
 
 use Quantum\Validation\Validator;
 use Quantum\Http\Enums\StatusCode;
-use Quantum\Middleware\QtMiddleware;
+use Quantum\Middleware\Middleware;
 use Quantum\Http\Response;
 use Quantum\Http\Request;
 use Closure;
@@ -25,7 +25,7 @@ use Closure;
  * Class BaseMiddleware
  * @package Modules\{{MODULE_NAME}}
  */
-abstract class BaseMiddleware extends QtMiddleware
+abstract class BaseMiddleware extends Middleware
 {
     protected $validator;
 

--- a/src/Module/Templates/DemoApi/src/Services/AuthService.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Services/AuthService.php.tpl
@@ -17,18 +17,18 @@ namespace {{MODULE_NAMESPACE}}\Services;
 use Quantum\Auth\Contracts\AuthServiceInterface;
 use Quantum\Config\Exceptions\ConfigException;
 use Quantum\Model\Exceptions\ModelException;
-use Quantum\Auth\User as AuthUser;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Di\Exceptions\DiException;
 use Quantum\Model\ModelCollection;
-use Quantum\Service\QtService;
+use Quantum\Auth\User as AuthUser;
+use Quantum\Service\Service;
 use {{MODULE_NAMESPACE}}\Models\User;
 
 /**
  * Class AuthService
  * @package Modules\{{MODULE_NAME}}
  */
-class AuthService extends QtService implements AuthServiceInterface
+class AuthService extends Service implements AuthServiceInterface
 {
 
     /**

--- a/src/Module/Templates/DemoApi/src/Services/CommentService.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Services/CommentService.php.tpl
@@ -18,7 +18,7 @@ use {{MODULE_NAMESPACE}}\Transformers\CommentTransformer;
 use Quantum\Model\Exceptions\ModelException;
 use Quantum\App\Exceptions\BaseException;
 use {{MODULE_NAMESPACE}}\DTOs\CommentDTO;
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 use {{MODULE_NAMESPACE}}\Models\Comment;
 use {{MODULE_NAMESPACE}}\Models\User;
 
@@ -26,7 +26,7 @@ use {{MODULE_NAMESPACE}}\Models\User;
  * Class CommentService
  * @package Modules\{{MODULE_NAME}}
  */
-class CommentService extends QtService
+class CommentService extends Service
 {
 
     /**

--- a/src/Module/Templates/DemoApi/src/Services/PostService.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Services/PostService.php.tpl
@@ -28,14 +28,14 @@ use {{MODULE_NAMESPACE}}\Models\Post;
 use Quantum\Di\Exceptions\DiException;
 use Quantum\Model\ModelCollection;
 use Gumlet\ImageResizeException;
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 use Quantum\Model\DbModel;
 
 /**
  * Class PostService
  * @package Modules\{{MODULE_NAME}}
  */
-class PostService extends QtService
+class PostService extends Service
 {
 
     /**

--- a/src/Module/Templates/DemoWeb/src/Controllers/CommentController.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Controllers/CommentController.php.tpl
@@ -16,6 +16,7 @@ namespace {{MODULE_NAMESPACE}}\Controllers;
 
 use {{MODULE_NAMESPACE}}\Services\CommentService;
 use {{MODULE_NAMESPACE}}\DTOs\CommentDTO;
+use Quantum\Http\Response;
 use Quantum\Http\Request;
 
 /**

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Auth.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Auth.php.tpl
@@ -14,7 +14,7 @@
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
 
-use Quantum\Middleware\QtMiddleware;
+use Quantum\Middleware\Middleware;
 use Quantum\Http\Response;
 use Quantum\Http\Request;
 use Closure;
@@ -23,7 +23,7 @@ use Closure;
  * Class Auth
  * @package Modules\{{MODULE_NAME}}
  */
-class Auth extends QtMiddleware
+class Auth extends Middleware
 {
     public function apply(Request $request, Closure $next): Response
     {

--- a/src/Module/Templates/DemoWeb/src/Middlewares/BaseMiddleware.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/BaseMiddleware.php.tpl
@@ -15,7 +15,7 @@
 namespace {{MODULE_NAMESPACE}}\Middlewares;
 
 use Quantum\Validation\Validator;
-use Quantum\Middleware\QtMiddleware;
+use Quantum\Middleware\Middleware;
 use Quantum\Http\Response;
 use Quantum\Http\Request;
 
@@ -23,7 +23,7 @@ use Quantum\Http\Request;
  * Class BaseMiddleware
  * @package Modules\{{MODULE_NAME}}
  */
-abstract class BaseMiddleware extends QtMiddleware
+abstract class BaseMiddleware extends Middleware
 {
     protected $validator;
 

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Guest.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Guest.php.tpl
@@ -14,7 +14,7 @@
 
 namespace {{MODULE_NAMESPACE}}\Middlewares;
 
-use Quantum\Middleware\QtMiddleware;
+use Quantum\Middleware\Middleware;
 use Quantum\Http\Response;
 use Quantum\Http\Request;
 use Closure;
@@ -23,7 +23,7 @@ use Closure;
  * Class Guest
  * @package Modules\{{MODULE_NAME}}
  */
-class Guest extends QtMiddleware
+class Guest extends Middleware
 {
     public function apply(Request $request, Closure $next): Response
     {

--- a/src/Module/Templates/DemoWeb/src/Services/AuthService.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Services/AuthService.php.tpl
@@ -17,18 +17,18 @@ namespace {{MODULE_NAMESPACE}}\Services;
 use Quantum\Auth\Contracts\AuthServiceInterface;
 use Quantum\Config\Exceptions\ConfigException;
 use Quantum\Model\Exceptions\ModelException;
-use Quantum\Auth\User as AuthUser;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Di\Exceptions\DiException;
 use Quantum\Model\ModelCollection;
-use Quantum\Service\QtService;
+use Quantum\Auth\User as AuthUser;
+use Quantum\Service\Service;
 use {{MODULE_NAMESPACE}}\Models\User;
 
 /**
  * Class AuthService
  * @package Modules\{{MODULE_NAME}}
  */
-class AuthService extends QtService implements AuthServiceInterface
+class AuthService extends Service implements AuthServiceInterface
 {
 
     /**

--- a/src/Module/Templates/DemoWeb/src/Services/CommandService.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Services/CommandService.php.tpl
@@ -16,13 +16,13 @@
 namespace {{MODULE_NAMESPACE}}\Services;
 
 use Quantum\Console\CommandDiscovery;
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 
 /**
  * Class CommandService
  * @package Modules\{{MODULE_NAME}}
  */
-class CommandService extends QtService
+class CommandService extends Service
 {
 
     /**

--- a/src/Module/Templates/DemoWeb/src/Services/CommentService.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Services/CommentService.php.tpl
@@ -18,7 +18,7 @@ use {{MODULE_NAMESPACE}}\Transformers\CommentTransformer;
 use Quantum\Model\Exceptions\ModelException;
 use Quantum\App\Exceptions\BaseException;
 use {{MODULE_NAMESPACE}}\DTOs\CommentDTO;
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 use {{MODULE_NAMESPACE}}\Models\Comment;
 use {{MODULE_NAMESPACE}}\Models\User;
 
@@ -26,7 +26,7 @@ use {{MODULE_NAMESPACE}}\Models\User;
  * Class CommentService
  * @package Modules\{{MODULE_NAME}}
  */
-class CommentService extends QtService
+class CommentService extends Service
 {
 
     /**

--- a/src/Module/Templates/DemoWeb/src/Services/PostService.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Services/PostService.php.tpl
@@ -28,13 +28,13 @@ use {{MODULE_NAMESPACE}}\Models\Post;
 use Quantum\Di\Exceptions\DiException;
 use Quantum\Model\ModelCollection;
 use Gumlet\ImageResizeException;
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 
 /**
  * Class PostService
  * @package Modules\{{MODULE_NAME}}
  */
-class PostService extends QtService
+class PostService extends Service
 {
 
     /**

--- a/src/Module/Templates/Toolkit/src/Controllers/EmailsController.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Controllers/EmailsController.php.tpl
@@ -64,6 +64,6 @@ class EmailsController extends BaseController
     {
         $this->emailService->deleteEmail($emailId);
 
-        redirect(base_url(true) . '/emails');
+        return redirect(base_url(true) . '/emails');
     }
 }

--- a/src/Module/Templates/Toolkit/src/Middlewares/BaseMiddleware.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Middlewares/BaseMiddleware.php.tpl
@@ -14,7 +14,7 @@
 
 namespace Modules\Toolkit\Middlewares;
 
-use Quantum\Middleware\QtMiddleware;
+use Quantum\Middleware\Middleware;
 use Quantum\Validation\Validator;
 use Quantum\Http\Response;
 use Quantum\Http\Request;
@@ -23,7 +23,7 @@ use Quantum\Http\Request;
  * Class BaseMiddleware
  * @package Modules\{{MODULE_NAME}}
  */
-abstract class BaseMiddleware extends QtMiddleware
+abstract class BaseMiddleware extends Middleware
 {
     protected Validator $validator;
 

--- a/src/Module/Templates/Toolkit/src/Middlewares/BasicAuth.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Middlewares/BasicAuth.php.tpl
@@ -14,7 +14,7 @@
 
 namespace Modules\Toolkit\Middlewares;
 
-use Quantum\Middleware\QtMiddleware;
+use Quantum\Middleware\Middleware;
 use Quantum\Loader\Setup;
 use Quantum\Http\Response;
 use Quantum\Http\Request;
@@ -24,7 +24,7 @@ use Closure;
  * Class BasicAuth
  * @package Modules\Toolkit
  */
-class BasicAuth extends QtMiddleware
+class BasicAuth extends Middleware
 {
     public function apply(Request $request, Closure $next): Response
     {

--- a/src/Module/Templates/Toolkit/src/Services/DashboardService.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Services/DashboardService.php.tpl
@@ -14,13 +14,13 @@
 
 namespace Modules\Toolkit\Services;
 
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 
 /**
  * Class DashboardService
  * @package Modules\Toolkit
  */
-class DashboardService extends QtService
+class DashboardService extends Service
 {
     public function __construct()
     {

--- a/src/Module/Templates/Toolkit/src/Services/DatabaseService.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Services/DatabaseService.php.tpl
@@ -19,14 +19,14 @@ use Quantum\Config\Exceptions\ConfigException;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Di\Exceptions\DiException;
 use Quantum\Paginator\Paginator;
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 use ReflectionException;
 
 /**
  * Class DatabaseService
  * @package Modules\Toolkit
  */
-class DatabaseService extends QtService
+class DatabaseService extends Service
 {
     /**
      * @var string

--- a/src/Module/Templates/Toolkit/src/Services/EmailService.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Services/EmailService.php.tpl
@@ -20,7 +20,7 @@ use Quantum\Paginator\Factories\PaginatorFactory;
 use Quantum\Paginator\Enums\PaginatorType;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Paginator\Paginator;
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 use Quantum\Mailer\MailTrap;
 use ReflectionException;
 use Quantum\Di\Di;
@@ -29,7 +29,7 @@ use Quantum\Di\Di;
  * Class EmailService
  * @package Modules\Toolkit
  */
-class EmailService extends QtService
+class EmailService extends Service
 {
     /**
      * @var string

--- a/src/Module/Templates/Toolkit/src/Services/LogsService.php.tpl
+++ b/src/Module/Templates/Toolkit/src/Services/LogsService.php.tpl
@@ -21,14 +21,14 @@ use Quantum\Paginator\Enums\PaginatorType;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Di\Exceptions\DiException;
 use Quantum\Paginator\Paginator;
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 use ReflectionException;
 
 /**
  * Class LogsService
  * @package Modules\Toolkit
  */
-class LogsService extends QtService
+class LogsService extends Service
 {
     /**
      * Retrieves a list of available log file names from the logs directory.

--- a/src/Service/Factories/ServiceFactory.php
+++ b/src/Service/Factories/ServiceFactory.php
@@ -19,7 +19,7 @@ namespace Quantum\Service\Factories;
 use Quantum\Service\Exceptions\ServiceException;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Di\Exceptions\DiException;
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 use ReflectionException;
 use Quantum\Di\Di;
 
@@ -31,7 +31,7 @@ class ServiceFactory
 {
     /**
      * Creates and initiates the service once
-     * @template T of QtService
+     * @template T of Service
      * @param class-string<T> $serviceClass
      * @param array<mixed> $args
      * @return T
@@ -40,7 +40,7 @@ class ServiceFactory
      * @throws ReflectionException
      * @throws ServiceException
      */
-    public static function get(string $serviceClass, array $args = []): QtService
+    public static function get(string $serviceClass, array $args = []): Service
     {
         self::validate($serviceClass);
 
@@ -53,7 +53,7 @@ class ServiceFactory
 
     /**
      * Creates new service instance
-     * @template T of QtService
+     * @template T of Service
      * @param class-string<T> $serviceClass
      * @param array<mixed> $args
      * @return T
@@ -62,7 +62,7 @@ class ServiceFactory
      * @throws ReflectionException
      * @throws ServiceException
      */
-    public static function create(string $serviceClass, array $args = []): QtService
+    public static function create(string $serviceClass, array $args = []): Service
     {
         self::validate($serviceClass);
 
@@ -80,8 +80,8 @@ class ServiceFactory
             throw ServiceException::notFound('Service', $serviceClass);
         }
 
-        if (!is_subclass_of($serviceClass, QtService::class)) {
-            throw ServiceException::notInstanceOf($serviceClass, QtService::class);
+        if (!is_subclass_of($serviceClass, Service::class)) {
+            throw ServiceException::notInstanceOf($serviceClass, Service::class);
         }
     }
 }

--- a/src/Service/Helpers/service.php
+++ b/src/Service/Helpers/service.php
@@ -16,7 +16,7 @@ use Quantum\Service\Exceptions\ServiceException;
 use Quantum\Service\Factories\ServiceFactory;
 use Quantum\App\Exceptions\BaseException;
 use Quantum\Di\Exceptions\DiException;
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 
 /**
  * Gets or creates service instance
@@ -26,9 +26,9 @@ use Quantum\Service\QtService;
  * @throws DiException
  * @throws ReflectionException
  * @throws ServiceException
- * @template T of QtService
+ * @template T of Service
  */
-function service(string $serviceClass, bool $singleton = false): QtService
+function service(string $serviceClass, bool $singleton = false): Service
 {
     return $singleton ? ServiceFactory::get($serviceClass) : ServiceFactory::create($serviceClass);
 }

--- a/src/Service/Service.php
+++ b/src/Service/Service.php
@@ -20,10 +20,10 @@ use Quantum\Service\Exceptions\ServiceException;
 use Quantum\App\Exceptions\BaseException;
 
 /**
- * Class QtService
+ * Class Service
  * @package Quantum\Service
  */
-class QtService
+abstract class Service
 {
     /**
      * Handles the missing methods of the service
@@ -33,6 +33,6 @@ class QtService
      */
     public function __call(string $method, array $arguments)
     {
-        throw ServiceException::methodNotSupported($method, QtService::class);
+        throw ServiceException::methodNotSupported($method, Service::class);
     }
 }

--- a/src/Storage/Factories/FileSystemFactory.php
+++ b/src/Storage/Factories/FileSystemFactory.php
@@ -143,7 +143,7 @@ class FileSystemFactory
     {
         $serviceClass = (string) config()->get('fs.' . $adapter . '.service');
 
-        /** @var class-string<\Quantum\Service\QtService> $serviceClass */
+        /** @var class-string<\Quantum\Service\Service> $serviceClass */
         $tokenService = ServiceFactory::create($serviceClass);
 
         if (!$tokenService instanceof TokenServiceInterface) {

--- a/tests/Unit/Console/CliCommandTest.php
+++ b/tests/Unit/Console/CliCommandTest.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Helper\HelperSet;
 use Quantum\Tests\Unit\AppTestCase;
 use RuntimeException;
 
-class QtCommandTest extends AppTestCase
+class CliCommandTest extends AppTestCase
 {
     private TestCommand $command;
 
@@ -27,7 +27,7 @@ class QtCommandTest extends AppTestCase
         $this->tester = new CommandTester($this->command);
     }
 
-    public function testQtCommandMetadataIsConfigured(): void
+    public function testCliCommandMetadataIsConfigured(): void
     {
         $this->assertSame('test:dummy', $this->command->getName());
 
@@ -36,7 +36,7 @@ class QtCommandTest extends AppTestCase
         $this->assertSame('Used only for core command discovery tests', $this->command->getHelp());
     }
 
-    public function testQtCommandArgumentsAndOptionsAreRegistered(): void
+    public function testCliCommandArgumentsAndOptionsAreRegistered(): void
     {
         $definition = $this->command->getDefinition();
 

--- a/tests/Unit/Console/CommandDiscoveryTest.php
+++ b/tests/Unit/Console/CommandDiscoveryTest.php
@@ -4,7 +4,7 @@ namespace Quantum\Tests\Unit\Console;
 
 use Quantum\Console\CommandDiscovery;
 use Quantum\Tests\Unit\AppTestCase;
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 
 class CommandDiscoveryTest extends AppTestCase
 {
@@ -36,7 +36,7 @@ class CommandDiscoveryTest extends AppTestCase
 
         $instance = new $command['class']();
 
-        $this->assertInstanceOf(QtCommand::class, $instance);
+        $this->assertInstanceOf(CliCommand::class, $instance);
 
         $this->assertNotEmpty($instance->getName());
     }

--- a/tests/Unit/Di/DiTest.php
+++ b/tests/Unit/Di/DiTest.php
@@ -27,7 +27,7 @@ namespace Quantum\Service {
     {
     }
 
-    class DummyService extends QtService implements DummyServiceInterface
+    class DummyService extends Service implements DummyServiceInterface
     {
     }
 

--- a/tests/Unit/Middleware/MiddlewareManagerTest.php
+++ b/tests/Unit/Middleware/MiddlewareManagerTest.php
@@ -1,12 +1,12 @@
 <?php
 
 namespace Quantum\Tests\_root\modules\Test\Middlewares {
-    use Quantum\Middleware\QtMiddleware;
+    use Quantum\Middleware\Middleware;
     use Quantum\Http\Request;
     use Quantum\Http\Response;
     use Closure;
 
-    class TestMwOne extends QtMiddleware
+    class TestMwOne extends Middleware
     {
         public static array $calls = [];
 
@@ -17,7 +17,7 @@ namespace Quantum\Tests\_root\modules\Test\Middlewares {
         }
     }
 
-    class TestMwTwo extends QtMiddleware
+    class TestMwTwo extends Middleware
     {
         public function apply(Request $request, Closure $next): Response
         {
@@ -28,7 +28,7 @@ namespace Quantum\Tests\_root\modules\Test\Middlewares {
         }
     }
 
-    class TestMwBlocker extends QtMiddleware
+    class TestMwBlocker extends Middleware
     {
         public function apply(Request $request, Closure $next): Response
         {
@@ -121,7 +121,7 @@ namespace Quantum\Tests\Unit\Middleware {
             $manager->applyMiddlewares(request(), fn (Request $request): Response => response()->json([]));
         }
 
-        public function testMiddlewareManagerThrowsWhenNotInstanceOfQtMiddleware(): void
+        public function testMiddlewareManagerThrowsWhenNotInstanceOfMiddleware(): void
         {
             $this->expectException(MiddlewareException::class);
 

--- a/tests/Unit/Migration/Exceptions/MigrationExceptionTest.php
+++ b/tests/Unit/Migration/Exceptions/MigrationExceptionTest.php
@@ -39,7 +39,7 @@ class MigrationExceptionTest extends AppTestCase
         $exception = MigrationException::invalidMigrationClass('FooMigration');
 
         $this->assertInstanceOf(MigrationException::class, $exception);
-        $this->assertSame('Migration class `FooMigration` must extend QtMigration', $exception->getMessage());
+        $this->assertSame('Migration class `FooMigration` must extend Migration', $exception->getMessage());
         $this->assertSame(E_ERROR, $exception->getCode());
     }
 }

--- a/tests/Unit/Migration/MigrationManagerTest.php
+++ b/tests/Unit/Migration/MigrationManagerTest.php
@@ -179,7 +179,7 @@ class MigrationManagerTest extends AppTestCase
         $manager = new MigrationManager();
 
         $this->expectException(MigrationException::class);
-        $this->expectExceptionMessage('Migration class `create_table_gamma_table_1003` must extend QtMigration');
+        $this->expectExceptionMessage('Migration class `create_table_gamma_table_1003` must extend Migration');
 
         $manager->applyMigrations(MigrationManager::UPGRADE);
     }
@@ -211,7 +211,7 @@ class MigrationManagerTest extends AppTestCase
     private function createValidMigrationFile(string $className, string $tableName): void
     {
         $content = "<?php\n"
-            . 'class ' . $className . " extends \\Quantum\\Migration\\QtMigration\n"
+            . 'class ' . $className . " extends \\Quantum\\Migration\\Migration\n"
             . "{\n"
             . "    public function up(\\Quantum\\Database\\Factories\\TableFactory \$tableFactory): void\n"
             . "    {\n"

--- a/tests/Unit/Migration/Templates/MigrationTemplateTest.php
+++ b/tests/Unit/Migration/Templates/MigrationTemplateTest.php
@@ -11,7 +11,8 @@ class MigrationTemplateTest extends AppTestCase
     {
         $template = MigrationTemplate::create('create_table_users_1001', 'users');
 
-        $this->assertStringContainsString('class Create_table_users_1001 extends QtMigration', $template);
+        $this->assertStringContainsString('use Quantum\Migration\Migration;', $template);
+        $this->assertStringContainsString('class Create_table_users_1001 extends Migration', $template);
         $this->assertStringContainsString("\$tableFactory->create('users')", $template);
         $this->assertStringContainsString("\$tableFactory->drop('users')", $template);
     }
@@ -20,7 +21,8 @@ class MigrationTemplateTest extends AppTestCase
     {
         $template = MigrationTemplate::alter('alter_table_users_1002', 'users');
 
-        $this->assertStringContainsString('class Alter_table_users_1002 extends QtMigration', $template);
+        $this->assertStringContainsString('use Quantum\Migration\Migration;', $template);
+        $this->assertStringContainsString('class Alter_table_users_1002 extends Migration', $template);
         $this->assertStringContainsString("\$tableFactory->get('users')", $template);
     }
 
@@ -28,7 +30,8 @@ class MigrationTemplateTest extends AppTestCase
     {
         $template = MigrationTemplate::rename('rename_table_users_1003', 'users');
 
-        $this->assertStringContainsString('class Rename_table_users_1003 extends QtMigration', $template);
+        $this->assertStringContainsString('use Quantum\Migration\Migration;', $template);
+        $this->assertStringContainsString('class Rename_table_users_1003 extends Migration', $template);
         $this->assertStringContainsString("\$tableFactory->rename('users', \$newName)", $template);
         $this->assertStringContainsString("\$tableFactory->rename(\$newName, 'users')", $template);
     }
@@ -37,7 +40,8 @@ class MigrationTemplateTest extends AppTestCase
     {
         $template = MigrationTemplate::drop('drop_table_users_1004', 'users');
 
-        $this->assertStringContainsString('class Drop_table_users_1004 extends QtMigration', $template);
+        $this->assertStringContainsString('use Quantum\Migration\Migration;', $template);
+        $this->assertStringContainsString('class Drop_table_users_1004 extends Migration', $template);
         $this->assertStringContainsString("\$tableFactory->drop('users')", $template);
     }
 }

--- a/tests/Unit/Service/Factories/ServiceFactoryTest.php
+++ b/tests/Unit/Service/Factories/ServiceFactoryTest.php
@@ -2,10 +2,10 @@
 
 namespace Quantum\Services {
 
-    use Quantum\Service\QtService;
+    use Quantum\Service\Service;
     use Quantum\Models\TestModel;
 
-    class TestService extends QtService
+    class TestService extends Service
     {
         public static $count = 0;
 
@@ -43,7 +43,7 @@ namespace Quantum\Tests\Unit\Service\Factories {
     use Quantum\Service\Factories\ServiceFactory;
     use Quantum\Tests\Unit\AppTestCase;
     use Quantum\Services\TestService;
-    use Quantum\Service\QtService;
+    use Quantum\Service\Service;
     use Quantum\Model\DbModel;
 
     class ServiceFactoryTest extends AppTestCase
@@ -62,7 +62,7 @@ namespace Quantum\Tests\Unit\Service\Factories {
         {
             $service = ServiceFactory::get(TestService::class);
 
-            $this->assertInstanceOf(QtService::class, $service);
+            $this->assertInstanceOf(Service::class, $service);
 
             $this->assertInstanceOf(TestService::class, $service);
         }
@@ -84,7 +84,7 @@ namespace Quantum\Tests\Unit\Service\Factories {
         {
             $service = ServiceFactory::create(TestService::class);
 
-            $this->assertInstanceOf(QtService::class, $service);
+            $this->assertInstanceOf(Service::class, $service);
 
             $this->assertInstanceOf(TestService::class, $service);
         }

--- a/tests/Unit/Service/Helpers/ServiceHelperFunctionTest.php
+++ b/tests/Unit/Service/Helpers/ServiceHelperFunctionTest.php
@@ -5,17 +5,17 @@ namespace Quantum\Tests\Unit\Service\Helpers;
 use Quantum\Tests\_root\shared\Services\TokenService;
 use Quantum\Service\Exceptions\ServiceException;
 use Quantum\Tests\Unit\AppTestCase;
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 
 class ServiceHelperFunctionTest extends AppTestCase
 {
-    public function testServiceReturnsQtServiceInstance(): void
+    public function testServiceReturnsServiceInstance(): void
     {
         $service = service(TokenService::class);
 
         $this->assertInstanceOf(TokenService::class, $service);
 
-        $this->assertInstanceOf(QtService::class, $service);
+        $this->assertInstanceOf(Service::class, $service);
     }
 
     public function testModelThrowsOnInvalidClass(): void

--- a/tests/Unit/Service/ServiceTest.php
+++ b/tests/Unit/Service/ServiceTest.php
@@ -2,9 +2,9 @@
 
 namespace Quantum\Services {
 
-    use Quantum\Service\QtService;
+    use Quantum\Service\Service;
 
-    class TestingService extends QtService
+    class TestingService extends Service
     {
     }
 }
@@ -15,13 +15,13 @@ namespace Quantum\Tests\Unit\Service {
     use Quantum\Service\Factories\ServiceFactory;
     use Quantum\Services\TestingService;
     use Quantum\Tests\Unit\AppTestCase;
-    use Quantum\Service\QtService;
+    use Quantum\Service\Service;
 
     /**
      * @runTestsInSeparateProcesses
      * @preserveGlobalState disabled
      */
-    class QtServiceTest extends AppTestCase
+    class ServiceTest extends AppTestCase
     {
         public function setUp(): void
         {
@@ -32,7 +32,7 @@ namespace Quantum\Tests\Unit\Service {
         {
             $this->expectException(ServiceException::class);
 
-            $this->expectExceptionMessage('The method `undefinedMethod` is not supported for `' . QtService::class . '`');
+            $this->expectExceptionMessage('The method `undefinedMethod` is not supported for `' . Service::class . '`');
 
             $service = (new ServiceFactory())->get(TestingService::class);
 

--- a/tests/_root/modules/Test/Services/AuthService.php
+++ b/tests/_root/modules/Test/Services/AuthService.php
@@ -3,10 +3,10 @@
 namespace Quantum\Tests\_root\modules\Test\Services;
 
 use Quantum\Auth\Contracts\AuthServiceInterface;
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 use Quantum\Auth\User;
 
-class AuthService extends QtService implements AuthServiceInterface
+class AuthService extends Service implements AuthServiceInterface
 {
     public function get(string $field, ?string $value): ?User
     {

--- a/tests/_root/shared/Commands/TestCommand.php
+++ b/tests/_root/shared/Commands/TestCommand.php
@@ -2,9 +2,9 @@
 
 namespace Quantum\Tests\_root\shared\Commands;
 
-use Quantum\Console\QtCommand;
+use Quantum\Console\CliCommand;
 
-class TestCommand extends QtCommand
+class TestCommand extends CliCommand
 {
     protected ?string $name = 'test:dummy';
     protected ?string $description = 'Dummy test command';

--- a/tests/_root/shared/Services/TokenService.php
+++ b/tests/_root/shared/Services/TokenService.php
@@ -3,9 +3,9 @@
 namespace Quantum\Tests\_root\shared\Services;
 
 use Quantum\Storage\Contracts\TokenServiceInterface;
-use Quantum\Service\QtService;
+use Quantum\Service\Service;
 
-class TokenService extends QtService implements TokenServiceInterface
+class TokenService extends Service implements TokenServiceInterface
 {
     public function getAccessToken(): string
     {


### PR DESCRIPTION
Closes #500 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified naming conventions for core framework base classes (Service, Middleware, Migration, and Console Command). Updated all framework implementations, module templates, and tests accordingly. **This is a breaking change in v3.0.0** requiring updates to custom implementations extending these base classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->