### PR TITLE
Issue/502 request context cleanup

### DIFF
--- a/src/App/Traits/WebAppTrait.php
+++ b/src/App/Traits/WebAppTrait.php
@@ -141,9 +141,12 @@ trait WebAppTrait
      */
     private function sendResponse(Response $response): void
     {
-        $this->handleCors($response);
-        $response->send();
-        $this->cleanupRequestContext();
+        try {
+            $this->handleCors($response);
+            $response->send();
+        } finally {
+            $this->cleanupRequestContext();
+        }
     }
 
     /**

--- a/src/App/Traits/WebAppTrait.php
+++ b/src/App/Traits/WebAppTrait.php
@@ -143,5 +143,16 @@ trait WebAppTrait
     {
         $this->handleCors($response);
         $response->send();
+        $this->cleanupRequestContext();
+    }
+
+    /**
+     * Clears request-scoped state after the response has been sent.
+     */
+    private function cleanupRequestContext(): void
+    {
+        request()->setMatchedRoute(null);
+        request()->flush();
+        response()->flush();
     }
 }

--- a/src/Module/Templates/DemoApi/src/Middlewares/Auth.php.tpl
+++ b/src/Module/Templates/DemoApi/src/Middlewares/Auth.php.tpl
@@ -28,7 +28,7 @@ class Auth extends BaseMiddleware
     public function apply(Request $request, Closure $next): Response
     {
         if (!auth()->check()) {
-            $this->respondWithError($request,
+            return $this->respondWithError($request,
                 t('validation.unauthorizedRequest'),
                 StatusCode::UNAUTHORIZED
             );

--- a/src/Module/Templates/DemoWeb/src/Middlewares/Auth.php.tpl
+++ b/src/Module/Templates/DemoWeb/src/Middlewares/Auth.php.tpl
@@ -28,7 +28,7 @@ class Auth extends Middleware
     public function apply(Request $request, Closure $next): Response
     {
         if (!auth()->check()) {
-            redirect(base_url(true) . '/' . current_lang() . '/signin');
+            return redirect(base_url(true) . '/' . current_lang() . '/signin');
         }
 
         return $next($request);

--- a/tests/Unit/App/Adapters/WebAppAdapterTest.php
+++ b/tests/Unit/App/Adapters/WebAppAdapterTest.php
@@ -2,8 +2,11 @@
 
 namespace Quantum\Tests\Unit\App\Adapters;
 
+use Quantum\Http\Exceptions\HttpException;
 use Quantum\App\Adapters\WebAppAdapter;
 use Quantum\Tests\Unit\AppTestCase;
+use Quantum\Router\Route;
+use Throwable;
 
 class WebAppAdapterTest extends AppTestCase
 {
@@ -61,6 +64,38 @@ class WebAppAdapterTest extends AppTestCase
         ob_end_clean();
 
         $this->assertSame(0, $result);
+        $this->assertNull(request()->getMatchedRoute());
+        $this->assertNull(request()->getUri());
+        $this->assertSame([], response()->all());
+        $this->assertSame([], response()->allHeaders());
+        $this->assertSame(200, response()->getStatusCode());
+    }
+
+    public function testWebAppAdapterCleansUpOnException(): void
+    {
+        request()->create('GET', '/test/am/tests');
+        request()->setMatchedRoute(null);
+        request()->setMatchedRoute(new \Quantum\Router\MatchedRoute(
+            new Route(['GET'], '/test/am/tests', 'TestController', 'tests'),
+            []
+        ));
+        response()->setHeader('X-Test', '1');
+        response()->json(['foo' => 'bar']);
+
+        $throwingResponse = new class () extends \Quantum\Http\Response {
+            public function send(): void
+            {
+                throw new HttpException('boom');
+            }
+        };
+
+        try {
+            $this->invokePrivateMethod($this->webAppAdapter, 'sendResponse', [$throwingResponse]);
+            $this->fail('Expected response sending to fail.');
+        } catch (Throwable $exception) {
+            $this->assertInstanceOf(HttpException::class, $exception);
+        }
+
         $this->assertNull(request()->getMatchedRoute());
         $this->assertNull(request()->getUri());
         $this->assertSame([], response()->all());

--- a/tests/Unit/App/Adapters/WebAppAdapterTest.php
+++ b/tests/Unit/App/Adapters/WebAppAdapterTest.php
@@ -29,6 +29,11 @@ class WebAppAdapterTest extends AppTestCase
         ob_end_clean();
 
         $this->assertEquals(0, $result);
+        $this->assertNull(request()->getMatchedRoute());
+        $this->assertNull(request()->getUri());
+        $this->assertSame([], response()->all());
+        $this->assertSame([], response()->allHeaders());
+        $this->assertSame(200, response()->getStatusCode());
     }
 
     public function testWebAppAdapterStartFails(): void
@@ -40,6 +45,11 @@ class WebAppAdapterTest extends AppTestCase
         ob_end_clean();
 
         $this->assertSame(0, $result);
+        $this->assertNull(request()->getMatchedRoute());
+        $this->assertNull(request()->getUri());
+        $this->assertSame([], response()->all());
+        $this->assertSame([], response()->allHeaders());
+        $this->assertSame(200, response()->getStatusCode());
     }
 
     public function testWebAppAdapterHandlesPageNotFoundGracefully(): void
@@ -51,5 +61,10 @@ class WebAppAdapterTest extends AppTestCase
         ob_end_clean();
 
         $this->assertSame(0, $result);
+        $this->assertNull(request()->getMatchedRoute());
+        $this->assertNull(request()->getUri());
+        $this->assertSame([], response()->all());
+        $this->assertSame([], response()->allHeaders());
+        $this->assertSame(200, response()->getStatusCode());
     }
 }


### PR DESCRIPTION
Closes #502 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication middleware now properly halts request processing when authorization or authentication checks fail, preventing unintended progression to subsequent middleware handlers.

* **Tests**
  * Enhanced test coverage to validate comprehensive cleanup of request context data and response states following request processing completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->