### PR TITLE
[#508] Support related criteria paths in SleekDB joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - PHP 8.4 forward compatibility: Added missing type hint to `SleekDbal::__get()` magic method
 - Fixed deprecated `E_STRICT` constant usage in test bootstrap
 - Fixed cURL error message assertions for cross-version compatibility
+- SleekDB adapter now supports related-model criteria path filtering across join depths while preserving DBAL public API (#508)
 
 ### Added
 - `AppContext` class representing the runtime identity of a single application execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,6 @@
 - PHP 8.4 forward compatibility: Added missing type hint to `SleekDbal::__get()` magic method
 - Fixed deprecated `E_STRICT` constant usage in test bootstrap
 - Fixed cURL error message assertions for cross-version compatibility
-- SleekDB adapter now supports related-model criteria path filtering across join depths while preserving DBAL public API (#508)
 
 ### Added
 - `AppContext` class representing the runtime identity of a single application execution
@@ -117,6 +116,7 @@
   - Added rate limit response headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `Retry-After`)
   - Added route-level metadata support on `Route` and `RouteBuilder` for rate limiting
   - Added unit test coverage for router integration, middleware flow, adapters, factory resolution, and exception behavior
+- SleekDB adapter now supports related-model criteria path filtering across join depths while preserving DBAL public API (#508)
 
 ### Removed
 - Support for PHP 7.3 and earlier versions

--- a/src/Database/Adapters/Sleekdb/SleekDbal.php
+++ b/src/Database/Adapters/Sleekdb/SleekDbal.php
@@ -409,15 +409,16 @@ class SleekDbal implements DbalInterface
         $this->rootCriterias = $this->criterias;
         $this->relatedCriteriasByPath = [];
         $this->requiredRelatedPaths = [];
-        $this->criteriaPrepared = true;
 
         if ($this->joins === [] || $this->criterias === []) {
+            $this->criteriaPrepared = true;
             return;
         }
 
         $joinPaths = $this->collectJoinPaths();
 
         if ($joinPaths === []) {
+            $this->criteriaPrepared = true;
             return;
         }
 
@@ -461,6 +462,7 @@ class SleekDbal implements DbalInterface
 
         $this->requiredRelatedPaths = array_values(array_unique($this->requiredRelatedPaths));
         $this->rootCriterias = $rootCriterias;
+        $this->criteriaPrepared = true;
     }
 
     /**

--- a/src/Database/Adapters/Sleekdb/SleekDbal.php
+++ b/src/Database/Adapters/Sleekdb/SleekDbal.php
@@ -146,12 +146,11 @@ class SleekDbal implements DbalInterface
      */
     public array $hidden = [];
 
-    /**
-     * ORM Model
-     */
     private ?Store $ormModel = null;
 
     private ?QueryBuilder $queryBuilder = null;
+
+    private bool $builderPrepared = false;
 
     /**
      * Active connection
@@ -308,8 +307,11 @@ class SleekDbal implements DbalInterface
     public function getBuilder(): QueryBuilder
     {
         $builder = $this->getQueryBuilder();
-        $this->prepareCriteriaScopesIfNeeded();
-        $this->applyBuilderModifiers($builder);
+        if (!$this->builderPrepared) {
+            $this->prepareCriteriaScopesIfNeeded();
+            $this->applyBuilderModifiers($builder);
+            $this->builderPrepared = true;
+        }
         return $builder;
     }
 
@@ -349,6 +351,7 @@ class SleekDbal implements DbalInterface
         $this->limit = null;
         $this->joins = [];
         $this->queryBuilder = null;
+        $this->builderPrepared = false;
     }
 
     /**

--- a/src/Database/Adapters/Sleekdb/SleekDbal.php
+++ b/src/Database/Adapters/Sleekdb/SleekDbal.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Quantum\Database\Adapters\Sleekdb;
 
+use Quantum\Database\Adapters\Sleekdb\Statements\RelatedCriteria;
 use Quantum\Database\Adapters\Sleekdb\Statements\Criteria;
 use Quantum\Database\Adapters\Sleekdb\Statements\Reducer;
 use Quantum\Database\Adapters\Sleekdb\Statements\Result;
@@ -28,9 +29,7 @@ use Quantum\Database\Contracts\DbalInterface;
 use Quantum\Model\Exceptions\ModelException;
 use Quantum\App\Exceptions\BaseException;
 use SleekDB\Exceptions\IOException;
-use Quantum\Model\DbModel;
 use SleekDB\QueryBuilder;
-use RuntimeException;
 use SleekDB\Store;
 
 /**
@@ -42,6 +41,7 @@ class SleekDbal implements DbalInterface
     use Model;
     use Result;
     use Criteria;
+    use RelatedCriteria;
     use Reducer;
     use Join;
 
@@ -352,244 +352,6 @@ class SleekDbal implements DbalInterface
     }
 
     /**
-     * Splits collected criteria into root-store and related-join scopes.
-     * Related path criteria are mapped to join paths and excluded from root where.
-     */
-    protected function prepareCriteriaScopes(): void
-    {
-        $this->rootCriterias = $this->criterias;
-        $this->relatedCriteriasByPath = [];
-        $this->requiredRelatedPaths = [];
-
-        if ($this->joins === [] || $this->criterias === []) {
-            $this->criteriaPrepared = true;
-            return;
-        }
-
-        $joinPaths = $this->collectJoinPaths();
-
-        if ($joinPaths === []) {
-            $this->criteriaPrepared = true;
-            return;
-        }
-
-        $rootCriterias = [];
-        $foundRelated = false;
-        $hasOr = false;
-
-        foreach ($this->criterias as $criteria) {
-            if (is_string($criteria)) {
-                $hasOr = $hasOr || strtoupper($criteria) === 'OR';
-                $rootCriterias[] = $criteria;
-                continue;
-            }
-
-            if (!is_array($criteria) || !isset($criteria[0]) || !is_string($criteria[0])) {
-                $rootCriterias[] = $criteria;
-                continue;
-            }
-
-            $column = $criteria[0];
-            $relatedMatch = $this->matchRelatedPath($column, $joinPaths);
-
-            if ($relatedMatch === null) {
-                $rootCriterias[] = $criteria;
-                continue;
-            }
-
-            $foundRelated = true;
-            $path = $relatedMatch['path'];
-            $localColumn = $relatedMatch['column'];
-
-            $this->relatedCriteriasByPath[$path][] = [$localColumn, $criteria[1], $criteria[2] ?? null];
-            $this->requiredRelatedPaths[] = $path;
-        }
-
-        if ($foundRelated && $hasOr) {
-            throw new RuntimeException(
-                'SleekDB related-model criterias do not support OR combinations with root/related scopes yet.'
-            );
-        }
-
-        $this->requiredRelatedPaths = array_values(array_unique($this->requiredRelatedPaths));
-        $this->rootCriterias = $rootCriterias;
-        $this->criteriaPrepared = true;
-    }
-
-    /**
-     * Builds all accessible join paths (including nested ones) from current join chain.
-     * @return array<int, string>
-     */
-    protected function collectJoinPaths(): array
-    {
-        $paths = [];
-        $this->collectJoinPathsRecursive($this->joins, 0, '', $paths);
-        usort($paths, static fn (string $a, string $b): int => substr_count($b, '.') <=> substr_count($a, '.'));
-        return array_values(array_unique($paths));
-    }
-
-    /**
-     * Recursively resolves join paths while respecting switch mode for same-level joins.
-     * @param array<int, array<string, mixed>> $joins
-     * @param array<int, string> $paths
-     */
-    protected function collectJoinPathsRecursive(array $joins, int $level, string $currentPath, array &$paths): void
-    {
-        if (!isset($joins[$level])) {
-            return;
-        }
-
-        $nextItem = $joins[$level];
-        $model = unserialize($nextItem['model']);
-
-        if (!$model instanceof DbModel) {
-            return;
-        }
-
-        $joinPath = $this->buildJoinPath($currentPath, $model->table);
-        $paths[] = $joinPath;
-
-        $switch = (bool) ($nextItem['switch'] ?? true);
-
-        if ($switch) {
-            $this->collectJoinPathsRecursive($joins, $level + 1, $joinPath, $paths);
-            return;
-        }
-
-        $this->collectJoinPathsRecursive($joins, $level + 1, $currentPath, $paths);
-    }
-
-    /**
-     * Matches a dotted criteria column to the deepest known join path.
-     * @param array<int, string> $joinPaths
-     * @return array{path:string,column:string}|null
-     */
-    protected function matchRelatedPath(string $column, array $joinPaths): ?array
-    {
-        $parts = explode('.', $column);
-
-        if (count($parts) <= 1) {
-            return null;
-        }
-
-        if ($parts[0] === $this->table) {
-            return null;
-        }
-
-        foreach ($joinPaths as $path) {
-            $pathParts = explode('.', $path);
-
-            if (count($parts) <= count($pathParts)) {
-                continue;
-            }
-
-            if (array_slice($parts, 0, count($pathParts)) !== $pathParts) {
-                continue;
-            }
-
-            $localColumn = implode('.', array_slice($parts, count($pathParts)));
-
-            return [
-                'path' => $path,
-                'column' => $localColumn,
-            ];
-        }
-
-        return null;
-    }
-
-    /**
-     * Removes parent rows that do not contain data on required related paths.
-     * @param array<int, array<string, mixed>> $results
-     * @return array<int, array<string, mixed>>
-     */
-    public function applyRelatedCriteriaPostFilter(array $results): array
-    {
-        if ($this->requiredRelatedPaths === []) {
-            return $results;
-        }
-
-        $results = array_values(array_filter($results, function (array $row): bool {
-            foreach ($this->requiredRelatedPaths as $path) {
-                if (!$this->pathHasData($row, explode('.', $path))) {
-                    return false;
-                }
-            }
-
-            return true;
-        }));
-
-        if ($this->autoSelectedRelatedRoots !== []) {
-            $results = $this->removeAutoSelectedRelatedRoots($results);
-        }
-
-        return $results;
-    }
-
-    /**
-     * Checks whether a nested relation path exists and contains at least one result.
-     * @param array<string, mixed> $row
-     * @param array<int, string> $segments
-     */
-    protected function pathHasData(array $row, array $segments): bool
-    {
-        $nodes = [$row];
-
-        foreach ($segments as $segment) {
-            $nextNodes = [];
-
-            foreach ($nodes as $node) {
-                if (!array_key_exists($segment, $node)) {
-                    continue;
-                }
-
-                $value = $node[$segment];
-
-                if (!is_array($value) || $value === []) {
-                    continue;
-                }
-
-                if ($this->isList($value)) {
-                    foreach ($value as $item) {
-                        if (is_array($item)) {
-                            $nextNodes[] = $item;
-                        }
-                    }
-                    continue;
-                }
-
-                $nextNodes[] = $value;
-            }
-
-            if ($nextNodes === []) {
-                return false;
-            }
-
-            $nodes = $nextNodes;
-        }
-
-        return true;
-    }
-
-    /**
-     * Determines whether the given array has sequential integer keys from zero.
-     * @param array<mixed> $value
-     */
-    protected function isList(array $value): bool
-    {
-        $index = 0;
-
-        foreach ($value as $key => $_) {
-            if ($key !== $index) {
-                return false;
-            }
-            $index++;
-        }
-
-        return true;
-    }
-
-    /**
      * Builds a dot-notated join path from current path and next relation table.
      */
     protected function buildJoinPath(string $currentPath, string $table): string
@@ -708,66 +470,4 @@ class SleekDbal implements DbalInterface
         }
     }
 
-    /**
-     * Adds related roots required for post-filtering to query selection only.
-     * @return array<string, mixed>
-     */
-    protected function buildSelectForQuery(): array
-    {
-        $selected = $this->selected;
-        $this->autoSelectedRelatedRoots = [];
-
-        if ($this->requiredRelatedPaths === []) {
-            return $selected;
-        }
-
-        foreach ($this->requiredRelatedPaths as $path) {
-            $relatedRoot = explode('.', $path)[0];
-
-            if ($this->selectReferencesRoot($selected, $relatedRoot)) {
-                continue;
-            }
-
-            $selected[] = $relatedRoot;
-            $this->autoSelectedRelatedRoots[] = $relatedRoot;
-        }
-
-        return $selected;
-    }
-
-    /**
-     * Checks whether current selection already references the given relation root.
-     * @param array<string, mixed> $selected
-     */
-    protected function selectReferencesRoot(array $selected, string $root): bool
-    {
-        foreach ($selected as $column) {
-            if (!is_string($column)) {
-                continue;
-            }
-
-            if ($column === $root || strpos($column, $root . '.') === 0) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Removes relation roots auto-selected only for post-filter evaluation.
-     * @param array<int, array<string, mixed>> $results
-     * @return array<int, array<string, mixed>>
-     */
-    protected function removeAutoSelectedRelatedRoots(array $results): array
-    {
-        foreach ($results as &$row) {
-            foreach ($this->autoSelectedRelatedRoots as $root) {
-                unset($row[$root]);
-            }
-        }
-        unset($row);
-
-        return $results;
-    }
 }

--- a/src/Database/Adapters/Sleekdb/SleekDbal.php
+++ b/src/Database/Adapters/Sleekdb/SleekDbal.php
@@ -28,7 +28,9 @@ use Quantum\Database\Contracts\DbalInterface;
 use Quantum\Model\Exceptions\ModelException;
 use Quantum\App\Exceptions\BaseException;
 use SleekDB\Exceptions\IOException;
+use Quantum\Model\DbModel;
 use SleekDB\QueryBuilder;
+use RuntimeException;
 use SleekDB\Store;
 
 /**
@@ -94,6 +96,23 @@ class SleekDbal implements DbalInterface
      * @var array<int, array<string, mixed>>
      */
     protected $joins = [];
+
+    /**
+     * @var array<int, array<int|string, mixed>|string>
+     */
+    protected array $rootCriterias = [];
+
+    /**
+     * @var array<string, array<int, array{0:string,1:string,2:mixed}>>
+     */
+    protected array $relatedCriteriasByPath = [];
+
+    /**
+     * @var array<int, string>
+     */
+    protected array $requiredRelatedPaths = [];
+
+    protected bool $criteriaPrepared = false;
 
     /**
      * Associated model name
@@ -299,6 +318,10 @@ class SleekDbal implements DbalInterface
             $this->queryBuilder = $builder;
         }
 
+        if (!$this->criteriaPrepared) {
+            $this->prepareCriteriaScopes();
+        }
+
         if ($this->selected !== []) {
             $builder->select($this->selected);
         }
@@ -307,8 +330,8 @@ class SleekDbal implements DbalInterface
             $this->applyJoins();
         }
 
-        if ($this->criterias !== []) {
-            $builder->where($this->criterias);
+        if ($this->rootCriterias !== []) {
+            $builder->where($this->rootCriterias);
         }
 
         if ($this->havings !== []) {
@@ -357,6 +380,10 @@ class SleekDbal implements DbalInterface
     protected function resetBuilderState(): void
     {
         $this->criterias = [];
+        $this->rootCriterias = [];
+        $this->relatedCriteriasByPath = [];
+        $this->requiredRelatedPaths = [];
+        $this->criteriaPrepared = false;
         $this->havings = [];
         $this->selected = [];
         $this->grouped = [];
@@ -365,5 +392,243 @@ class SleekDbal implements DbalInterface
         $this->limit = null;
         $this->joins = [];
         $this->queryBuilder = null;
+    }
+
+    /**
+     * Splits collected criteria into root-store and related-join scopes.
+     * Related path criteria are mapped to join paths and excluded from root where.
+     */
+    protected function prepareCriteriaScopes(): void
+    {
+        $this->rootCriterias = $this->criterias;
+        $this->relatedCriteriasByPath = [];
+        $this->requiredRelatedPaths = [];
+        $this->criteriaPrepared = true;
+
+        if ($this->joins === [] || $this->criterias === []) {
+            return;
+        }
+
+        $joinPaths = $this->collectJoinPaths();
+
+        if ($joinPaths === []) {
+            return;
+        }
+
+        $rootCriterias = [];
+        $foundRelated = false;
+        $hasOr = false;
+
+        foreach ($this->criterias as $criteria) {
+            if (is_string($criteria)) {
+                $hasOr = $hasOr || strtoupper($criteria) === 'OR';
+                $rootCriterias[] = $criteria;
+                continue;
+            }
+
+            if (!is_array($criteria) || !isset($criteria[0]) || !is_string($criteria[0])) {
+                $rootCriterias[] = $criteria;
+                continue;
+            }
+
+            $column = $criteria[0];
+            $relatedMatch = $this->matchRelatedPath($column, $joinPaths);
+
+            if ($relatedMatch === null) {
+                $rootCriterias[] = $criteria;
+                continue;
+            }
+
+            $foundRelated = true;
+            $path = $relatedMatch['path'];
+            $localColumn = $relatedMatch['column'];
+
+            $this->relatedCriteriasByPath[$path][] = [$localColumn, $criteria[1], $criteria[2] ?? null];
+            $this->requiredRelatedPaths[] = $path;
+        }
+
+        if ($foundRelated && $hasOr) {
+            throw new RuntimeException(
+                'SleekDB related-model criterias do not support OR combinations with root/related scopes yet.'
+            );
+        }
+
+        $this->requiredRelatedPaths = array_values(array_unique($this->requiredRelatedPaths));
+        $this->rootCriterias = $rootCriterias;
+    }
+
+    /**
+     * Builds all accessible join paths (including nested ones) from current join chain.
+     * @return array<int, string>
+     */
+    protected function collectJoinPaths(): array
+    {
+        $paths = [];
+        $this->collectJoinPathsRecursive($this->joins, 0, '', $paths);
+        usort($paths, static fn (string $a, string $b): int => substr_count($b, '.') <=> substr_count($a, '.'));
+        return array_values(array_unique($paths));
+    }
+
+    /**
+     * Recursively resolves join paths while respecting switch mode for same-level joins.
+     * @param array<int, array<string, mixed>> $joins
+     * @param array<int, string> $paths
+     */
+    protected function collectJoinPathsRecursive(array $joins, int $level, string $currentPath, array &$paths): void
+    {
+        if (!isset($joins[$level])) {
+            return;
+        }
+
+        $nextItem = $joins[$level];
+        $model = unserialize($nextItem['model']);
+
+        if (!$model instanceof DbModel) {
+            return;
+        }
+
+        $joinPath = $this->buildJoinPath($currentPath, $model->table);
+        $paths[] = $joinPath;
+
+        $switch = (bool) ($nextItem['switch'] ?? true);
+
+        if ($switch) {
+            $this->collectJoinPathsRecursive($joins, $level + 1, $joinPath, $paths);
+            return;
+        }
+
+        $this->collectJoinPathsRecursive($joins, $level + 1, $currentPath, $paths);
+    }
+
+    /**
+     * Matches a dotted criteria column to the deepest known join path.
+     * @param array<int, string> $joinPaths
+     * @return array{path:string,column:string}|null
+     */
+    protected function matchRelatedPath(string $column, array $joinPaths): ?array
+    {
+        $parts = explode('.', $column);
+
+        if (count($parts) <= 1) {
+            return null;
+        }
+
+        if ($parts[0] === $this->table) {
+            return null;
+        }
+
+        foreach ($joinPaths as $path) {
+            $pathParts = explode('.', $path);
+
+            if (count($parts) <= count($pathParts)) {
+                continue;
+            }
+
+            if (array_slice($parts, 0, count($pathParts)) !== $pathParts) {
+                continue;
+            }
+
+            $localColumn = implode('.', array_slice($parts, count($pathParts)));
+
+            return [
+                'path' => $path,
+                'column' => $localColumn,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Removes parent rows that do not contain data on required related paths.
+     * @param array<int, array<string, mixed>> $results
+     * @return array<int, array<string, mixed>>
+     */
+    public function applyRelatedCriteriaPostFilter(array $results): array
+    {
+        if ($this->requiredRelatedPaths === []) {
+            return $results;
+        }
+
+        return array_values(array_filter($results, function (array $row): bool {
+            foreach ($this->requiredRelatedPaths as $path) {
+                if (!$this->pathHasData($row, explode('.', $path))) {
+                    return false;
+                }
+            }
+
+            return true;
+        }));
+    }
+
+    /**
+     * Checks whether a nested relation path exists and contains at least one result.
+     * @param array<string, mixed> $row
+     * @param array<int, string> $segments
+     */
+    protected function pathHasData(array $row, array $segments): bool
+    {
+        $nodes = [$row];
+
+        foreach ($segments as $segment) {
+            $nextNodes = [];
+
+            foreach ($nodes as $node) {
+                if (!array_key_exists($segment, $node)) {
+                    continue;
+                }
+
+                $value = $node[$segment];
+
+                if (!is_array($value) || $value === []) {
+                    continue;
+                }
+
+                if ($this->isList($value)) {
+                    foreach ($value as $item) {
+                        if (is_array($item)) {
+                            $nextNodes[] = $item;
+                        }
+                    }
+                    continue;
+                }
+
+                $nextNodes[] = $value;
+            }
+
+            if ($nextNodes === []) {
+                return false;
+            }
+
+            $nodes = $nextNodes;
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines whether the given array has sequential integer keys from zero.
+     * @param array<mixed> $value
+     */
+    protected function isList(array $value): bool
+    {
+        $index = 0;
+
+        foreach ($value as $key => $_) {
+            if ($key !== $index) {
+                return false;
+            }
+            $index++;
+        }
+
+        return true;
+    }
+
+    /**
+     * Builds a dot-notated join path from current path and next relation table.
+     */
+    protected function buildJoinPath(string $currentPath, string $table): string
+    {
+        return $currentPath !== '' ? $currentPath . '.' . $table : $table;
     }
 }

--- a/src/Database/Adapters/Sleekdb/SleekDbal.php
+++ b/src/Database/Adapters/Sleekdb/SleekDbal.php
@@ -255,11 +255,7 @@ class SleekDbal implements DbalInterface
 
     /**
      * Gets the ORM model
-     * @throws DatabaseException
-     * @throws IOException
-     * @throws InvalidArgumentException
-     * @throws InvalidConfigurationException
-     * @throws BaseException
+     * @throws DatabaseException|BaseException|IOException|InvalidArgumentException|InvalidConfigurationException
      */
     public function getOrmModel(): Store
     {
@@ -307,58 +303,13 @@ class SleekDbal implements DbalInterface
 
     /**
      * Gets the query builder object
-     * @throws BaseException
-     * @throws DatabaseException
-     * @throws IOException
-     * @throws InvalidArgumentException
-     * @throws InvalidConfigurationException
-     * @throws ModelException
+     * @throws ModelException|DatabaseException|BaseException|IOException|InvalidArgumentException|InvalidConfigurationException
      */
     public function getBuilder(): QueryBuilder
     {
-        $builder = $this->queryBuilder;
-
-        if (!$builder) {
-            $builder = $this->getOrmModel()->createQueryBuilder();
-            $this->queryBuilder = $builder;
-        }
-
-        if (!$this->criteriaPrepared) {
-            $this->prepareCriteriaScopes();
-        }
-
-        if ($this->selected !== []) {
-            $builder->select($this->buildSelectForQuery());
-        }
-
-        if ($this->joins !== []) {
-            $this->applyJoins();
-        }
-
-        if ($this->rootCriterias !== []) {
-            $builder->where($this->rootCriterias);
-        }
-
-        if ($this->havings !== []) {
-            $builder->having($this->havings);
-        }
-
-        if ($this->grouped !== []) {
-            $builder->groupBy($this->grouped);
-        }
-
-        if ($this->ordered !== []) {
-            $builder->orderBy($this->ordered);
-        }
-
-        if ($this->offset) {
-            $builder->skip($this->offset);
-        }
-
-        if ($this->limit) {
-            $builder->limit($this->limit);
-        }
-
+        $builder = $this->getQueryBuilder();
+        $this->prepareCriteriaScopesIfNeeded();
+        $this->applyBuilderModifiers($builder);
         return $builder;
     }
 
@@ -644,6 +595,117 @@ class SleekDbal implements DbalInterface
     protected function buildJoinPath(string $currentPath, string $table): string
     {
         return $currentPath !== '' ? $currentPath . '.' . $table : $table;
+    }
+
+    /**
+     * Ensures a reusable query builder instance exists for current adapter state.
+     * @return QueryBuilder
+     * @throws BaseException
+     * @throws DatabaseException
+     * @throws IOException
+     * @throws InvalidArgumentException
+     * @throws InvalidConfigurationException
+     */
+    protected function getQueryBuilder(): QueryBuilder
+    {
+        if ($this->queryBuilder === null) {
+            $this->queryBuilder = $this->getOrmModel()->createQueryBuilder();
+        }
+
+        return $this->queryBuilder;
+    }
+
+    /**
+     * Prepares root/related criteria scopes once per builder lifecycle.
+     */
+    protected function prepareCriteriaScopesIfNeeded(): void
+    {
+        if (!$this->criteriaPrepared) {
+            $this->prepareCriteriaScopes();
+        }
+    }
+
+    /**
+     * Applies all collected query modifiers on the given builder.
+     * @throws ModelException|InvalidArgumentException
+     */
+    protected function applyBuilderModifiers(QueryBuilder $builder): void
+    {
+        $this->applySelectModifier($builder);
+        $this->applyJoinModifier();
+        $this->applyWhereModifier($builder);
+        $this->applyHavingModifier($builder);
+        $this->applyGroupModifier($builder);
+        $this->applyOrderModifier($builder);
+        $this->applyPaginationModifier($builder);
+    }
+
+    protected function applySelectModifier(QueryBuilder $builder): void
+    {
+        if ($this->selected !== []) {
+            $builder->select($this->buildSelectForQuery());
+        }
+    }
+
+    /**
+     * @throws ModelException
+     */
+    protected function applyJoinModifier(): void
+    {
+        if ($this->joins !== []) {
+            $this->applyJoins();
+        }
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function applyWhereModifier(QueryBuilder $builder): void
+    {
+        if ($this->rootCriterias !== []) {
+            $builder->where($this->rootCriterias);
+        }
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function applyHavingModifier(QueryBuilder $builder): void
+    {
+        if ($this->havings !== []) {
+            $builder->having($this->havings);
+        }
+    }
+
+    protected function applyGroupModifier(QueryBuilder $builder): void
+    {
+        if ($this->grouped !== []) {
+            $builder->groupBy($this->grouped);
+        }
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function applyOrderModifier(QueryBuilder $builder): void
+    {
+        if ($this->ordered !== []) {
+            $builder->orderBy($this->ordered);
+        }
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function applyPaginationModifier(QueryBuilder $builder): void
+    {
+        if ($this->offset) {
+            $builder->skip($this->offset);
+        }
+
+        if ($this->limit) {
+            $builder->limit($this->limit);
+        }
     }
 
     /**

--- a/src/Database/Adapters/Sleekdb/SleekDbal.php
+++ b/src/Database/Adapters/Sleekdb/SleekDbal.php
@@ -115,6 +115,11 @@ class SleekDbal implements DbalInterface
     protected bool $criteriaPrepared = false;
 
     /**
+     * @var array<int, string>
+     */
+    protected array $autoSelectedRelatedRoots = [];
+
+    /**
      * Associated model name
      */
     private ?string $modelName;
@@ -323,7 +328,7 @@ class SleekDbal implements DbalInterface
         }
 
         if ($this->selected !== []) {
-            $builder->select($this->selected);
+            $builder->select($this->buildSelectForQuery());
         }
 
         if ($this->joins !== []) {
@@ -384,6 +389,7 @@ class SleekDbal implements DbalInterface
         $this->relatedCriteriasByPath = [];
         $this->requiredRelatedPaths = [];
         $this->criteriaPrepared = false;
+        $this->autoSelectedRelatedRoots = [];
         $this->havings = [];
         $this->selected = [];
         $this->grouped = [];
@@ -550,7 +556,7 @@ class SleekDbal implements DbalInterface
             return $results;
         }
 
-        return array_values(array_filter($results, function (array $row): bool {
+        $results = array_values(array_filter($results, function (array $row): bool {
             foreach ($this->requiredRelatedPaths as $path) {
                 if (!$this->pathHasData($row, explode('.', $path))) {
                     return false;
@@ -559,6 +565,12 @@ class SleekDbal implements DbalInterface
 
             return true;
         }));
+
+        if ($this->autoSelectedRelatedRoots !== []) {
+            $results = $this->removeAutoSelectedRelatedRoots($results);
+        }
+
+        return $results;
     }
 
     /**
@@ -630,5 +642,68 @@ class SleekDbal implements DbalInterface
     protected function buildJoinPath(string $currentPath, string $table): string
     {
         return $currentPath !== '' ? $currentPath . '.' . $table : $table;
+    }
+
+    /**
+     * Adds related roots required for post-filtering to query selection only.
+     * @return array<string, mixed>
+     */
+    protected function buildSelectForQuery(): array
+    {
+        $selected = $this->selected;
+        $this->autoSelectedRelatedRoots = [];
+
+        if ($this->requiredRelatedPaths === []) {
+            return $selected;
+        }
+
+        foreach ($this->requiredRelatedPaths as $path) {
+            $relatedRoot = explode('.', $path)[0];
+
+            if ($this->selectReferencesRoot($selected, $relatedRoot)) {
+                continue;
+            }
+
+            $selected[] = $relatedRoot;
+            $this->autoSelectedRelatedRoots[] = $relatedRoot;
+        }
+
+        return $selected;
+    }
+
+    /**
+     * Checks whether current selection already references the given relation root.
+     * @param array<string, mixed> $selected
+     */
+    protected function selectReferencesRoot(array $selected, string $root): bool
+    {
+        foreach ($selected as $column) {
+            if (!is_string($column)) {
+                continue;
+            }
+
+            if ($column === $root || strpos($column, $root . '.') === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Removes relation roots auto-selected only for post-filter evaluation.
+     * @param array<int, array<string, mixed>> $results
+     * @return array<int, array<string, mixed>>
+     */
+    protected function removeAutoSelectedRelatedRoots(array $results): array
+    {
+        foreach ($results as &$row) {
+            foreach ($this->autoSelectedRelatedRoots as $root) {
+                unset($row[$root]);
+            }
+        }
+        unset($row);
+
+        return $results;
     }
 }

--- a/src/Database/Adapters/Sleekdb/Statements/Join.php
+++ b/src/Database/Adapters/Sleekdb/Statements/Join.php
@@ -31,6 +31,8 @@ use RuntimeException;
  */
 trait Join
 {
+    abstract protected function buildJoinPath(string $currentPath, string $table): string;
+
     /**
      * @inheritDoc
      */

--- a/src/Database/Adapters/Sleekdb/Statements/Join.php
+++ b/src/Database/Adapters/Sleekdb/Statements/Join.php
@@ -55,7 +55,7 @@ trait Join
                 throw new RuntimeException('Cannot apply joins without an initialized query builder.');
             }
 
-            $this->applyJoin($this->queryBuilder, $this, $this->joins[0]);
+            $this->applyJoin($this->queryBuilder, $this, $this->joins[0], 1, '');
         }
     }
 
@@ -64,8 +64,13 @@ trait Join
      * @param array<string, mixed> $nextItem
      * @throws ModelException
      */
-    private function applyJoin(QueryBuilder $queryBuilder, SleekDbal $currentItem, array $nextItem, int $level = 1): QueryBuilder
-    {
+    private function applyJoin(
+        QueryBuilder $queryBuilder,
+        SleekDbal $currentItem,
+        array $nextItem,
+        int $level = 1,
+        string $currentPath = ''
+    ): QueryBuilder {
         $modelToJoin = unserialize($nextItem['model']);
         $switch = $nextItem['switch'];
 
@@ -73,7 +78,9 @@ trait Join
             throw new RuntimeException('Failed to unserialize join model.');
         }
 
-        $queryBuilder->join(function ($item) use ($currentItem, $modelToJoin, $switch, $level) {
+        $joinPath = $this->buildJoinPath($currentPath, $modelToJoin->table);
+
+        $queryBuilder->join(function ($item) use ($currentItem, $modelToJoin, $switch, $level, $joinPath) {
 
             $sleekModel = new self(
                 $modelToJoin->table,
@@ -85,9 +92,10 @@ trait Join
             $newQueryBuilder = $sleekModel->getOrmModel()->createQueryBuilder();
 
             $this->applyJoinTo($newQueryBuilder, $modelToJoin, $currentItem, $item);
+            $this->applyRelatedCriteriaToJoin($newQueryBuilder, $joinPath);
 
             if ($switch && isset($this->joins[$level])) {
-                $this->applyJoin($newQueryBuilder, $sleekModel, $this->joins[$level], $level + 1);
+                $this->applyJoin($newQueryBuilder, $sleekModel, $this->joins[$level], $level + 1, $joinPath);
             }
 
             return $newQueryBuilder;
@@ -95,10 +103,24 @@ trait Join
         }, $modelToJoin->table);
 
         if (!$switch && isset($this->joins[$level])) {
-            $this->applyJoin($queryBuilder, $currentItem, $this->joins[$level], $level + 1);
+            $this->applyJoin($queryBuilder, $currentItem, $this->joins[$level], $level + 1, $currentPath);
         }
 
         return $queryBuilder;
+    }
+
+    /**
+     * Applies criteria assigned to a specific join path on that join subquery.
+     */
+    private function applyRelatedCriteriaToJoin(QueryBuilder $queryBuilder, string $joinPath): void
+    {
+        if (!isset($this->relatedCriteriasByPath[$joinPath])) {
+            return;
+        }
+
+        foreach ($this->relatedCriteriasByPath[$joinPath] as $criteria) {
+            $queryBuilder->where($criteria);
+        }
     }
 
     /**

--- a/src/Database/Adapters/Sleekdb/Statements/RelatedCriteria.php
+++ b/src/Database/Adapters/Sleekdb/Statements/RelatedCriteria.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Quantum PHP Framework
+ *
+ * An open source software development framework for PHP
+ *
+ * @package Quantum
+ * @author Arman Ag. <arman.ag@softberg.org>
+ * @copyright Copyright (c) 2018 Softberg LLC (https://softberg.org)
+ * @link http://quantum.softberg.org/
+ * @since 3.0.0
+ */
+
+namespace Quantum\Database\Adapters\Sleekdb\Statements;
+
+use Quantum\Model\DbModel;
+use RuntimeException;
+
+/**
+ * Trait RelatedCriteria
+ * @package Quantum\Database
+ */
+trait RelatedCriteria
+{
+    abstract protected function buildJoinPath(string $currentPath, string $table): string;
+
+    /**
+     * Splits collected criteria into root-store and related-join scopes.
+     * Related path criteria are mapped to join paths and excluded from root where.
+     */
+    protected function prepareCriteriaScopes(): void
+    {
+        $this->rootCriterias = $this->criterias;
+        $this->relatedCriteriasByPath = [];
+        $this->requiredRelatedPaths = [];
+
+        if ($this->joins === [] || $this->criterias === []) {
+            $this->criteriaPrepared = true;
+            return;
+        }
+
+        $joinPaths = $this->collectJoinPaths();
+
+        if ($joinPaths === []) {
+            $this->criteriaPrepared = true;
+            return;
+        }
+
+        $rootCriterias = [];
+        $foundRelated = false;
+        $hasOr = false;
+
+        foreach ($this->criterias as $criteria) {
+            if (is_string($criteria)) {
+                $hasOr = $hasOr || strtoupper($criteria) === 'OR';
+                $rootCriterias[] = $criteria;
+                continue;
+            }
+
+            if (!is_array($criteria) || !isset($criteria[0]) || !is_string($criteria[0])) {
+                $rootCriterias[] = $criteria;
+                continue;
+            }
+
+            $column = $criteria[0];
+            $relatedMatch = $this->matchRelatedPath($column, $joinPaths);
+
+            if ($relatedMatch === null) {
+                $rootCriterias[] = $criteria;
+                continue;
+            }
+
+            $foundRelated = true;
+            $path = $relatedMatch['path'];
+            $localColumn = $relatedMatch['column'];
+
+            $this->relatedCriteriasByPath[$path][] = [$localColumn, $criteria[1], $criteria[2] ?? null];
+            $this->requiredRelatedPaths[] = $path;
+        }
+
+        if ($foundRelated && $hasOr) {
+            throw new RuntimeException(
+                'SleekDB related-model criterias do not support OR combinations with root/related scopes yet.'
+            );
+        }
+
+        $this->requiredRelatedPaths = array_values(array_unique($this->requiredRelatedPaths));
+        $this->rootCriterias = $rootCriterias;
+        $this->criteriaPrepared = true;
+    }
+
+    /**
+     * Builds all accessible join paths (including nested ones) from current join chain.
+     * @return array<int, string>
+     */
+    protected function collectJoinPaths(): array
+    {
+        $paths = [];
+        $this->collectJoinPathsRecursive($this->joins, 0, '', $paths);
+        usort($paths, static fn (string $a, string $b): int => substr_count($b, '.') <=> substr_count($a, '.'));
+        return array_values(array_unique($paths));
+    }
+
+    /**
+     * Recursively resolves join paths while respecting switch mode for same-level joins.
+     * @param array<int, array<string, mixed>> $joins
+     * @param array<int, string> $paths
+     */
+    protected function collectJoinPathsRecursive(array $joins, int $level, string $currentPath, array &$paths): void
+    {
+        if (!isset($joins[$level])) {
+            return;
+        }
+
+        $nextItem = $joins[$level];
+        $model = unserialize($nextItem['model']);
+
+        if (!$model instanceof DbModel) {
+            return;
+        }
+
+        $joinPath = $this->buildJoinPath($currentPath, $model->table);
+        $paths[] = $joinPath;
+
+        $switch = (bool) ($nextItem['switch'] ?? true);
+
+        if ($switch) {
+            $this->collectJoinPathsRecursive($joins, $level + 1, $joinPath, $paths);
+            return;
+        }
+
+        $this->collectJoinPathsRecursive($joins, $level + 1, $currentPath, $paths);
+    }
+
+    /**
+     * Matches a dotted criteria column to the deepest known join path.
+     * @param array<int, string> $joinPaths
+     * @return array{path:string,column:string}|null
+     */
+    protected function matchRelatedPath(string $column, array $joinPaths): ?array
+    {
+        $parts = explode('.', $column);
+
+        if (count($parts) <= 1) {
+            return null;
+        }
+
+        if ($parts[0] === $this->table) {
+            return null;
+        }
+
+        foreach ($joinPaths as $path) {
+            $pathParts = explode('.', $path);
+
+            if (count($parts) <= count($pathParts)) {
+                continue;
+            }
+
+            if (array_slice($parts, 0, count($pathParts)) !== $pathParts) {
+                continue;
+            }
+
+            $localColumn = implode('.', array_slice($parts, count($pathParts)));
+
+            return [
+                'path' => $path,
+                'column' => $localColumn,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Removes parent rows that do not contain data on required related paths.
+     * @param array<int, array<string, mixed>> $results
+     * @return array<int, array<string, mixed>>
+     */
+    public function applyRelatedCriteriaPostFilter(array $results): array
+    {
+        if ($this->requiredRelatedPaths === []) {
+            return $results;
+        }
+
+        $results = array_values(array_filter($results, function (array $row): bool {
+            foreach ($this->requiredRelatedPaths as $path) {
+                if (!$this->pathHasData($row, explode('.', $path))) {
+                    return false;
+                }
+            }
+
+            return true;
+        }));
+
+        if ($this->autoSelectedRelatedRoots !== []) {
+            $results = $this->removeAutoSelectedRelatedRoots($results);
+        }
+
+        return $results;
+    }
+
+    /**
+     * Checks whether a nested relation path exists and contains at least one result.
+     * @param array<string, mixed> $row
+     * @param array<int, string> $segments
+     */
+    protected function pathHasData(array $row, array $segments): bool
+    {
+        $nodes = [$row];
+
+        foreach ($segments as $segment) {
+            $nextNodes = [];
+
+            foreach ($nodes as $node) {
+                if (!array_key_exists($segment, $node)) {
+                    continue;
+                }
+
+                $value = $node[$segment];
+
+                if (!is_array($value) || $value === []) {
+                    continue;
+                }
+
+                if ($this->isList($value)) {
+                    foreach ($value as $item) {
+                        if (is_array($item)) {
+                            $nextNodes[] = $item;
+                        }
+                    }
+                    continue;
+                }
+
+                $nextNodes[] = $value;
+            }
+
+            if ($nextNodes === []) {
+                return false;
+            }
+
+            $nodes = $nextNodes;
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines whether the given array has sequential integer keys from zero.
+     * @param array<mixed> $value
+     */
+    protected function isList(array $value): bool
+    {
+        $index = 0;
+
+        foreach ($value as $key => $_) {
+            if ($key !== $index) {
+                return false;
+            }
+            $index++;
+        }
+
+        return true;
+    }
+
+    /**
+     * Adds related roots required for post-filtering to query selection only.
+     * @return array<string, mixed>
+     */
+    protected function buildSelectForQuery(): array
+    {
+        $selected = $this->selected;
+        $this->autoSelectedRelatedRoots = [];
+
+        if ($this->requiredRelatedPaths === []) {
+            return $selected;
+        }
+
+        foreach ($this->requiredRelatedPaths as $path) {
+            $relatedRoot = explode('.', $path)[0];
+
+            if ($this->selectReferencesRoot($selected, $relatedRoot)) {
+                continue;
+            }
+
+            $selected[] = $relatedRoot;
+            $this->autoSelectedRelatedRoots[] = $relatedRoot;
+        }
+
+        return $selected;
+    }
+
+    /**
+     * Checks whether current selection already references the given relation root.
+     * @param array<string, mixed> $selected
+     */
+    protected function selectReferencesRoot(array $selected, string $root): bool
+    {
+        foreach ($selected as $column) {
+            if (!is_string($column)) {
+                continue;
+            }
+
+            if ($column === $root || strpos($column, $root . '.') === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Removes relation roots auto-selected only for post-filter evaluation.
+     * @param array<int, array<string, mixed>> $results
+     * @return array<int, array<string, mixed>>
+     */
+    protected function removeAutoSelectedRelatedRoots(array $results): array
+    {
+        foreach ($results as &$row) {
+            foreach ($this->autoSelectedRelatedRoots as $root) {
+                unset($row[$root]);
+            }
+        }
+        unset($row);
+
+        return $results;
+    }
+}

--- a/src/Database/Adapters/Sleekdb/Statements/Result.php
+++ b/src/Database/Adapters/Sleekdb/Statements/Result.php
@@ -23,6 +23,7 @@ use Quantum\Database\Contracts\DbalInterface;
 use Quantum\Model\Exceptions\ModelException;
 use Quantum\App\Exceptions\BaseException;
 use SleekDB\Exceptions\IOException;
+use SleekDB\QueryBuilder;
 
 /**
  * Trait Result
@@ -38,7 +39,7 @@ trait Result
     public function get(): array
     {
         try {
-            $results = $this->fetchFilteredResults();
+            $results = $this->fetchFilteredResultsFromBuilder($this->getBuilder());
 
             return array_map(function ($element): object {
                 $item = clone $this;
@@ -62,8 +63,9 @@ trait Result
     public function findOne(int $id): DbalInterface
     {
         try {
-            $this->getBuilder()->where(['id', '=', $id]);
-            $results = $this->fetchFilteredResults();
+            $builder = $this->getBuilder();
+            $builder->where(['id', '=', $id]);
+            $results = $this->fetchFilteredResultsFromBuilder($builder);
             $result = $results[0] ?? [];
             $this->updateOrmModel($result);
         } finally {
@@ -85,8 +87,9 @@ trait Result
     public function findOneBy(string $column, $value): DbalInterface
     {
         try {
-            $this->getBuilder()->where([$column, '=', $value]);
-            $results = $this->fetchFilteredResults();
+            $builder = $this->getBuilder();
+            $builder->where([$column, '=', $value]);
+            $results = $this->fetchFilteredResultsFromBuilder($builder);
             $result = $results[0] ?? [];
             $this->updateOrmModel($result);
         } finally {
@@ -103,7 +106,7 @@ trait Result
     public function first(): DbalInterface
     {
         try {
-            $results = $this->fetchFilteredResults();
+            $results = $this->fetchFilteredResultsFromBuilder($this->getBuilder());
             $result = $results[0] ?? [];
             $this->updateOrmModel($result);
         } finally {
@@ -119,7 +122,7 @@ trait Result
     public function count(): int
     {
         try {
-            $results = $this->fetchFilteredResults();
+            $results = $this->fetchFilteredResultsFromBuilder($this->getBuilder());
             return count($results);
         } finally {
             $this->resetBuilderState();
@@ -150,22 +153,12 @@ trait Result
     }
 
     /**
-     * Applies adapter-specific post-fetch filters when available (SleekDB only).
-     * @param array<int, array<string, mixed>> $results
+     * Fetches results from given builder and applies post-fetch filters.
+     * @param QueryBuilder $builder
      * @return array<int, array<string, mixed>>
      */
-    protected function applyPostFetchFilters(array $results): array
+    protected function fetchFilteredResultsFromBuilder(QueryBuilder $builder): array
     {
-        return $this->applyRelatedCriteriaPostFilter($results);
-    }
-
-    /**
-     * Fetches current query results and applies post-fetch filters.
-     * @return array<int, array<string, mixed>>
-     * @throws ModelException|DatabaseException|BaseException|IOException|InvalidArgumentException|InvalidConfigurationException
-     */
-    protected function fetchFilteredResults(): array
-    {
-        return $this->applyPostFetchFilters($this->getBuilder()->getQuery()->fetch());
+        return $this->applyRelatedCriteriaPostFilter($builder->getQuery()->fetch());
     }
 }

--- a/src/Database/Adapters/Sleekdb/Statements/Result.php
+++ b/src/Database/Adapters/Sleekdb/Statements/Result.php
@@ -49,6 +49,7 @@ trait Result
 
             return array_map(function ($element): object {
                 $item = clone $this;
+                $item->resetBuilderState();
                 $item->updateOrmModel($element);
                 return $item;
             }, $results);

--- a/src/Database/Adapters/Sleekdb/Statements/Result.php
+++ b/src/Database/Adapters/Sleekdb/Statements/Result.php
@@ -34,6 +34,12 @@ trait Result
     abstract protected function resetBuilderState(): void;
 
     /**
+     * @param array<int, array<string, mixed>> $results
+     * @return array<int, array<string, mixed>>
+     */
+    abstract protected function applyRelatedCriteriaPostFilter(array $results): array;
+
+    /**
      * @inheritDoc
      */
     public function get(): array

--- a/src/Database/Adapters/Sleekdb/Statements/Result.php
+++ b/src/Database/Adapters/Sleekdb/Statements/Result.php
@@ -38,11 +38,13 @@ trait Result
     public function get(): array
     {
         try {
+            $results = $this->fetchFilteredResults();
+
             return array_map(function ($element): object {
                 $item = clone $this;
                 $item->updateOrmModel($element);
                 return $item;
-            }, $this->getBuilder()->getQuery()->fetch());
+            }, $results);
         } finally {
             $this->resetBuilderState();
         }
@@ -60,7 +62,9 @@ trait Result
     public function findOne(int $id): DbalInterface
     {
         try {
-            $result = $this->getBuilder()->where(['id', '=', $id])->getQuery()->first();
+            $this->getBuilder()->where(['id', '=', $id]);
+            $results = $this->fetchFilteredResults();
+            $result = $results[0] ?? [];
             $this->updateOrmModel($result);
         } finally {
             $this->resetBuilderState();
@@ -81,7 +85,9 @@ trait Result
     public function findOneBy(string $column, $value): DbalInterface
     {
         try {
-            $result = $this->getBuilder()->where([$column, '=', $value])->getQuery()->first();
+            $this->getBuilder()->where([$column, '=', $value]);
+            $results = $this->fetchFilteredResults();
+            $result = $results[0] ?? [];
             $this->updateOrmModel($result);
         } finally {
             $this->resetBuilderState();
@@ -92,17 +98,13 @@ trait Result
 
     /**
      * @inheritDoc
-     * @throws BaseException
-     * @throws DatabaseException
-     * @throws IOException
-     * @throws InvalidArgumentException
-     * @throws InvalidConfigurationException
-     * @throws ModelException
+     * @throws ModelException|DatabaseException|BaseException|IOException|InvalidArgumentException|InvalidConfigurationException
      */
     public function first(): DbalInterface
     {
         try {
-            $result = $this->getBuilder()->getQuery()->first();
+            $results = $this->fetchFilteredResults();
+            $result = $results[0] ?? [];
             $this->updateOrmModel($result);
         } finally {
             $this->resetBuilderState();
@@ -113,16 +115,15 @@ trait Result
 
     /**
      * @inheritDoc
-     * @throws DatabaseException
-     * @throws IOException
-     * @throws InvalidArgumentException
-     * @throws InvalidConfigurationException
-     * @throws ModelException
-     * @throws BaseException
      */
     public function count(): int
     {
-        return count($this->getBuilder()->getQuery()->fetch());
+        try {
+            $results = $this->fetchFilteredResults();
+            return count($results);
+        } finally {
+            $this->resetBuilderState();
+        }
     }
 
     /**
@@ -146,5 +147,25 @@ trait Result
     public function setHidden(array $result): array
     {
         return array_diff_key($result, array_flip($this->hidden));
+    }
+
+    /**
+     * Applies adapter-specific post-fetch filters when available (SleekDB only).
+     * @param array<int, array<string, mixed>> $results
+     * @return array<int, array<string, mixed>>
+     */
+    protected function applyPostFetchFilters(array $results): array
+    {
+        return $this->applyRelatedCriteriaPostFilter($results);
+    }
+
+    /**
+     * Fetches current query results and applies post-fetch filters.
+     * @return array<int, array<string, mixed>>
+     * @throws ModelException|DatabaseException|BaseException|IOException|InvalidArgumentException|InvalidConfigurationException
+     */
+    protected function fetchFilteredResults(): array
+    {
+        return $this->applyPostFetchFilters($this->getBuilder()->getQuery()->fetch());
     }
 }

--- a/tests/Unit/Database/Adapters/Sleekdb/Statements/JoinSleekTest.php
+++ b/tests/Unit/Database/Adapters/Sleekdb/Statements/JoinSleekTest.php
@@ -369,4 +369,36 @@ class JoinSleekTest extends SleekDbalTestCase
         $this->assertInstanceOf(ModelCollection::class, $users);
         $this->assertCount(0, $users);
     }
+
+    public function testSleekRelatedCriteriaWithRootSelectKeepsMatchedRow(): void
+    {
+        $userModel = ModelFactory::get(TestUserModel::class);
+        $profileModel = ModelFactory::get(TestProfileModel::class);
+
+        $users = $userModel
+            ->joinTo($profileModel)
+            ->criteria('profiles.firstname', '=', 'Jane')
+            ->select('email')
+            ->get();
+
+        $this->assertGreaterThan(0, $users->count());
+        $this->assertIsString($users->first()->email);
+        $this->assertNull($users->first()->prop('profiles'));
+    }
+
+    public function testSleekRelatedCriteriaWithAliasedSelectKeepsMatchedRow(): void
+    {
+        $userModel = ModelFactory::get(TestUserModel::class);
+        $profileModel = ModelFactory::get(TestProfileModel::class);
+
+        $users = $userModel
+            ->joinTo($profileModel)
+            ->criteria('profiles.firstname', '=', 'Jane')
+            ->select(['email' => 'user_email'])
+            ->get();
+
+        $this->assertGreaterThan(0, $users->count());
+        $this->assertIsString($users->first()->user_email);
+        $this->assertNull($users->first()->prop('profiles'));
+    }
 }

--- a/tests/Unit/Database/Adapters/Sleekdb/Statements/JoinSleekTest.php
+++ b/tests/Unit/Database/Adapters/Sleekdb/Statements/JoinSleekTest.php
@@ -292,4 +292,81 @@ class JoinSleekTest extends SleekDbalTestCase
             ->joinTo(ModelFactory::get(TestUserModel::class))
             ->get();
     }
+
+    public function testSleekRelatedCriteriaFiltersJoinedLevel(): void
+    {
+        $userModel = ModelFactory::get(TestUserModel::class);
+        $profileModel = ModelFactory::get(TestProfileModel::class);
+
+        $users = $userModel
+            ->joinTo($profileModel)
+            ->criteria('profiles.firstname', '=', 'Jane')
+            ->get();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals('jane@test.com', $users->first()->email);
+        $this->assertEquals('Jane', $users->first()->prop('profiles')[0]['firstname']);
+    }
+
+    public function testSleekDeepRelatedCriteriaFiltersNestedJoinLevel(): void
+    {
+        $userModel = ModelFactory::get(TestUserModel::class);
+        $meetingModel = ModelFactory::get(TestUserMeetingModel::class);
+        $ticketModel = ModelFactory::get(TestTicketModel::class);
+
+        $users = $userModel
+            ->joinTo($meetingModel)
+            ->joinTo($ticketModel)
+            ->criteria('user_meetings.tickets.type', '=', 'regular')
+            ->get();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals('john@test.com', $users->first()->email);
+    }
+
+    public function testSleekRootAndRelatedCriteriaWithAnd(): void
+    {
+        $userModel = ModelFactory::get(TestUserModel::class);
+        $profileModel = ModelFactory::get(TestProfileModel::class);
+
+        $users = $userModel
+            ->joinTo($profileModel)
+            ->criteria('email', 'LIKE', '%jane%')
+            ->criteria('profiles.country', '=', 'England')
+            ->get();
+
+        $this->assertCount(1, $users);
+        $this->assertEquals('jane@test.com', $users->first()->email);
+    }
+
+    public function testSleekRelatedCriteriaRejectsOrCombination(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('SleekDB related-model criterias do not support OR combinations');
+
+        $userModel = ModelFactory::get(TestUserModel::class);
+        $profileModel = ModelFactory::get(TestProfileModel::class);
+
+        $userModel
+            ->joinTo($profileModel)
+            ->criterias(
+                ['profiles.firstname', '=', 'Jane'],
+                [['email', 'LIKE', '%john%'], ['email', 'LIKE', '%jane%']]
+            )
+            ->get();
+    }
+
+    public function testSleekInvalidRelatedCriteriaPathReturnsNoMatches(): void
+    {
+        $userModel = ModelFactory::get(TestUserModel::class);
+        $profileModel = ModelFactory::get(TestProfileModel::class);
+
+        $users = $userModel
+            ->joinTo($profileModel)
+            ->criteria('unknown_relation.firstname', '=', 'Jane')
+            ->get();
+
+        $this->assertInstanceOf(ModelCollection::class, $users);
+        $this->assertCount(0, $users);
+    }
 }

--- a/tests/Unit/Database/Adapters/Sleekdb/Statements/JoinSleekTest.php
+++ b/tests/Unit/Database/Adapters/Sleekdb/Statements/JoinSleekTest.php
@@ -368,6 +368,9 @@ class JoinSleekTest extends SleekDbalTestCase
 
         $this->assertInstanceOf(ModelCollection::class, $users);
         $this->assertCount(0, $users);
+
+        $usersWithoutBadCriterion = ModelFactory::get(TestUserModel::class)->get();
+        $this->assertGreaterThan(0, $usersWithoutBadCriterion->count());
     }
 
     public function testSleekRelatedCriteriaWithRootSelectKeepsMatchedRow(): void


### PR DESCRIPTION
Closes #508 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SleekDB adapter now correctly filters queries using criteria that reference related/joined models across nested join depths, preserving result semantics.

* **Tests**
  * Added comprehensive tests for related-model criteria: immediate joins, deep nested joins, combined root+related criteria, invalid paths, and unsupported OR-style related criteria.

* **Documentation**
  * Changelog updated to note the SleekDB related-model criteria fix.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softberg/quantum-php-core/pull/509)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->