### PR TITLE
[#511] Fix RouteBuilder post-group modifier chaining context

### DIFF
--- a/src/Router/RouteBuilder.php
+++ b/src/Router/RouteBuilder.php
@@ -85,6 +85,7 @@ final class RouteBuilder
             $this->currentModule = null;
             $this->currentPrefix = null;
             $this->currentRoute = null;
+            $this->lastGroupRoutes = null;
         }
 
         return $this->collection;
@@ -160,6 +161,7 @@ final class RouteBuilder
             throw RouteException::nestedGroups();
         }
 
+        $this->lastGroupRoutes = null;
         $this->currentGroupName = $name;
         $this->inGroup = true;
         $this->groupRoutes = [];
@@ -210,7 +212,6 @@ final class RouteBuilder
                 $route->addMiddlewares($middlewares);
             }
 
-            $this->lastGroupRoutes = null;
             return $this;
         }
 
@@ -263,7 +264,6 @@ final class RouteBuilder
                 $route->cache($enabled, $ttl);
             }
 
-            $this->lastGroupRoutes = null;
             return $this;
         }
 
@@ -295,7 +295,6 @@ final class RouteBuilder
                 $route->rateLimit($limit, $interval);
             }
 
-            $this->lastGroupRoutes = null;
             return $this;
         }
 
@@ -323,6 +322,7 @@ final class RouteBuilder
             throw RouteException::noHttpMethods();
         }
 
+        $this->lastGroupRoutes = null;
         $pattern = $this->resolvePath($path);
 
         if ($handler instanceof Closure) {

--- a/tests/Unit/Router/RouteBuilderTest.php
+++ b/tests/Unit/Router/RouteBuilderTest.php
@@ -611,4 +611,58 @@ class RouteBuilderTest extends AppTestCase
         $this->assertSame('g', $routes->all()[0]->getGroup());
         $this->assertSame('g', $routes->all()[1]->getGroup());
     }
+
+    public function testRouteBuilderPostGroupMiddlewaresThenRateLimitCanBeChained(): void
+    {
+        $routes = (new RouteBuilder())->build([
+            'Web' => function (RouteBuilder $route): void {
+                $route->group('g', function (RouteBuilder $route): void {
+                    $route->get('a', 'AController', 'a');
+                    $route->get('b', 'BController', 'b');
+                })->middlewares(['Auth'])->rateLimit(10, 60);
+            },
+        ], []);
+
+        foreach ($routes->all() as $route) {
+            $this->assertSame(['Auth'], $route->getMiddlewares());
+            $this->assertSame(['limit' => 10, 'interval' => 60], $route->getRateLimit());
+        }
+    }
+
+    public function testRouteBuilderPostGroupRateLimitThenMiddlewaresCanBeChained(): void
+    {
+        $routes = (new RouteBuilder())->build([
+            'Web' => function (RouteBuilder $route): void {
+                $route->group('g', function (RouteBuilder $route): void {
+                    $route->get('a', 'AController', 'a');
+                    $route->get('b', 'BController', 'b');
+                })->rateLimit(20, 30)->middlewares(['Auth']);
+            },
+        ], []);
+
+        foreach ($routes->all() as $route) {
+            $this->assertSame(['Auth'], $route->getMiddlewares());
+            $this->assertSame(['limit' => 20, 'interval' => 30], $route->getRateLimit());
+        }
+    }
+
+    public function testRouteBuilderPostGroupCacheableAndOtherModifiersCanBeChained(): void
+    {
+        $routes = (new RouteBuilder())->build([
+            'Web' => function (RouteBuilder $route): void {
+                $route->group('g', function (RouteBuilder $route): void {
+                    $route->get('a', 'AController', 'a');
+                    $route->get('b', 'BController', 'b');
+                })->cacheable(true, 120)->rateLimit(50, 60)->middlewares(['Auth']);
+            },
+        ], []);
+
+        foreach ($routes->all() as $route) {
+            $cache = $route->getCache();
+            $this->assertSame(true, $cache['enabled']);
+            $this->assertSame(120, $cache['ttl']);
+            $this->assertSame(['limit' => 50, 'interval' => 60], $route->getRateLimit());
+            $this->assertSame(['Auth'], $route->getMiddlewares());
+        }
+    }
 }


### PR DESCRIPTION
Closes #511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route modifier chaining behavior on grouped routes, ensuring middlewares, rate limiting, and caching work correctly when applied in any order.

* **Tests**
  * Added unit tests to verify modifier chaining on grouped routes in multiple combinations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softberg/quantum-php-core/pull/512)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->