### PR TITLE
[#514] Preserve SleekDB criteria state across paginator count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - PHP 8.4 forward compatibility: Added missing type hint to `SleekDbal::__get()` magic method
 - Fixed deprecated `E_STRICT` constant usage in test bootstrap
 - Fixed cURL error message assertions for cross-version compatibility
+- Fixed SleekDB paginator query-state regression where `count()` could clear criteria before paginated data fetch on the same model instance (#514)
 
 ### Added
 - `AppContext` class representing the runtime identity of a single application execution

--- a/src/Database/Adapters/Sleekdb/Statements/Result.php
+++ b/src/Database/Adapters/Sleekdb/Statements/Result.php
@@ -128,12 +128,11 @@ trait Result
      */
     public function count(): int
     {
-        try {
-            $results = $this->fetchFilteredResultsFromBuilder($this->getBuilder());
-            return count($results);
-        } finally {
-            $this->resetBuilderState();
-        }
+        $counter = clone $this;
+        $counter->queryBuilder = null;
+        $counter->builderPrepared = false;
+
+        return count($counter->fetchFilteredResultsFromBuilder($counter->getBuilder()));
     }
 
     /**

--- a/src/Database/Adapters/Sleekdb/Statements/Result.php
+++ b/src/Database/Adapters/Sleekdb/Statements/Result.php
@@ -128,11 +128,12 @@ trait Result
      */
     public function count(): int
     {
-        $counter = clone $this;
-        $counter->queryBuilder = null;
-        $counter->builderPrepared = false;
-
-        return count($counter->fetchFilteredResultsFromBuilder($counter->getBuilder()));
+        try {
+            $results = $this->fetchFilteredResultsFromBuilder($this->getBuilder());
+            return count($results);
+        } finally {
+            $this->resetBuilderState();
+        }
     }
 
     /**

--- a/src/Paginator/Adapters/ModelPaginator.php
+++ b/src/Paginator/Adapters/ModelPaginator.php
@@ -19,6 +19,7 @@ namespace Quantum\Paginator\Adapters;
 use Quantum\Paginator\Contracts\PaginatorInterface;
 use Quantum\Paginator\Traits\PaginatorTrait;
 use Quantum\App\Exceptions\BaseException;
+use Quantum\Model\Exceptions\ModelException;
 use Quantum\Di\Exceptions\DiException;
 use Quantum\Model\ModelCollection;
 use Quantum\Model\DbModel;
@@ -38,7 +39,7 @@ class ModelPaginator implements PaginatorInterface
     private DbModel $model;
 
     /**
-     * @throws DiException|ReflectionException
+     * @throws DiException|ReflectionException|ModelException|BaseException
      */
     public function __construct(DbModel $model, int $perPage, int $page = 1)
     {
@@ -46,7 +47,7 @@ class ModelPaginator implements PaginatorInterface
 
         $this->model = $model;
         $this->modelClass = $model->getModelName();
-        $this->total = $model->count();
+        $this->total = $this->getCountFromClonedModel($model);
     }
 
     /**
@@ -98,5 +99,18 @@ class ModelPaginator implements PaginatorInterface
         }
 
         return $data->last();
+    }
+
+    /**
+     * Counts results on an isolated model/ORM clone so total calculation cannot mutate
+     * the live model query state later used by paginator data().
+     * @throws ModelException|BaseException
+     */
+    private function getCountFromClonedModel(DbModel $model): int
+    {
+        $countModel = clone $model;
+        $countModel->setOrmInstance(clone $model->getOrmInstance());
+
+        return $countModel->count();
     }
 }

--- a/tests/Unit/Database/Adapters/Sleekdb/Statements/ResultSleekTest.php
+++ b/tests/Unit/Database/Adapters/Sleekdb/Statements/ResultSleekTest.php
@@ -3,6 +3,7 @@
 namespace Quantum\Tests\Unit\Database\Adapters\Sleekdb\Statements;
 
 use Quantum\Tests\Unit\Database\Adapters\Sleekdb\SleekDbalTestCase;
+use Quantum\Tests\_root\shared\Models\TestEventModel;
 use Quantum\Database\Adapters\Sleekdb\SleekDbal;
 
 class ResultSleekTest extends SleekDbalTestCase
@@ -84,5 +85,36 @@ class ResultSleekTest extends SleekDbalTestCase
         $this->assertIsObject($user);
 
         $this->assertIsArray($user->asArray());
+    }
+
+    public function testSleekCountDoesNotResetCriteriaState(): void
+    {
+        $eventsModel = new SleekDbal('events');
+
+        $eventsModel->criteria('country', '=', 'Ireland');
+
+        $this->assertEquals(3, $eventsModel->count());
+
+        $events = $eventsModel
+            ->orderBy('title', 'asc')
+            ->get();
+
+        $this->assertCount(3, $events);
+        $this->assertEquals('Design', $events[0]->prop('title'));
+    }
+
+    public function testSleekPaginateRetainsCriteriaAfterCount(): void
+    {
+        $eventModel = model(TestEventModel::class);
+
+        $page = $eventModel
+            ->criteria('country', '=', 'Ireland')
+            ->orderBy('title', 'asc')
+            ->paginate(2, 1)
+            ->data();
+
+        $this->assertCount(2, $page);
+        $this->assertEquals('Design', $page->first()->title);
+        $this->assertEquals('Film', $page->last()->title);
     }
 }

--- a/tests/Unit/Database/Adapters/Sleekdb/Statements/ResultSleekTest.php
+++ b/tests/Unit/Database/Adapters/Sleekdb/Statements/ResultSleekTest.php
@@ -87,7 +87,7 @@ class ResultSleekTest extends SleekDbalTestCase
         $this->assertIsArray($user->asArray());
     }
 
-    public function testSleekCountDoesNotResetCriteriaState(): void
+    public function testSleekCountResetsCriteriaState(): void
     {
         $eventsModel = new SleekDbal('events');
 
@@ -99,8 +99,8 @@ class ResultSleekTest extends SleekDbalTestCase
             ->orderBy('title', 'asc')
             ->get();
 
-        $this->assertCount(3, $events);
-        $this->assertEquals('Design', $events[0]->prop('title'));
+        $this->assertCount(7, $events);
+        $this->assertEquals('Art', $events[0]->prop('title'));
     }
 
     public function testSleekPaginateRetainsCriteriaAfterCount(): void

--- a/tests/Unit/Database/Adapters/Sleekdb/Statements/ResultSleekTest.php
+++ b/tests/Unit/Database/Adapters/Sleekdb/Statements/ResultSleekTest.php
@@ -117,4 +117,38 @@ class ResultSleekTest extends SleekDbalTestCase
         $this->assertEquals('Design', $page->first()->title);
         $this->assertEquals('Film', $page->last()->title);
     }
+
+    public function testSleekGroupedCriteriasPersistAcrossPaginateCountAndData(): void
+    {
+        $baseline = model(TestEventModel::class)
+            ->criterias(
+                [
+                    ['title', '=', 'Dance'],
+                    ['title', '=', 'Art'],
+                ],
+                ['country', '=', 'Ireland']
+            )
+            ->orderBy('title', 'asc')
+            ->get();
+
+        $paginator = model(TestEventModel::class)
+            ->criterias(
+                [
+                    ['title', '=', 'Dance'],
+                    ['title', '=', 'Art'],
+                ],
+                ['country', '=', 'Ireland']
+            )
+            ->orderBy('title', 'asc')
+            ->paginate(10, 1);
+
+        $page = $paginator->data();
+
+        $baselineTitles = array_map(fn ($event) => $event->title, iterator_to_array($baseline));
+        $pageTitles = array_map(fn ($event) => $event->title, iterator_to_array($page));
+
+        $this->assertSame(count($baseline), $paginator->total());
+        $this->assertCount(count($baseline), $page);
+        $this->assertSame($baselineTitles, $pageTitles);
+    }
 }


### PR DESCRIPTION
Fixes #514 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression in pagination where applied query criteria could be inadvertently cleared before a subsequent paginated data fetch on the same model instance.

* **Tests**
  * Added comprehensive unit test coverage to verify that query criteria persist correctly and reliably across pagination operations, including tests for chained and grouped criteria scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softberg/quantum-php-core/pull/515)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->