### PR TITLE
[#532] Fix debugger replay for array payloads

### DIFF
--- a/src/Debugger/Debugger.php
+++ b/src/Debugger/Debugger.php
@@ -174,7 +174,7 @@ class Debugger
 
         foreach ($messages as $message) {
             $fn = key($message);
-            $this->debugBar[$type]->$fn($message[$fn]);
+            $this->debugBar[$type]->log($fn, $message[$fn]);
         }
     }
 

--- a/src/Debugger/Debugger.php
+++ b/src/Debugger/Debugger.php
@@ -166,16 +166,33 @@ class Debugger
      */
     protected function createTab(string $type): void
     {
-        if (!$this->debugBar->hasCollector($type)) {
-            $this->debugBar->addCollector(new MessagesCollector($type));
-        }
+        $collector = $this->resolveMessagesCollector($type);
 
         $messages = $this->store->get($type);
 
         foreach ($messages as $message) {
             $fn = key($message);
-            $this->debugBar[$type]->log($fn, $message[$fn]);
+            $collector->log($fn, $message[$fn]);
         }
+    }
+
+    /**
+     * Ensures the requested debug tab collector can accept mixed message payloads.
+     * @throws DebugBarException
+     */
+    protected function resolveMessagesCollector(string $type): MessagesCollector
+    {
+        if (!$this->debugBar->hasCollector($type)) {
+            $this->debugBar->addCollector(new MessagesCollector($type));
+        }
+
+        $collector = $this->debugBar->getCollector($type);
+
+        if (!$collector instanceof MessagesCollector) {
+            throw new DebugBarException("Collector '{$type}' must be a MessagesCollector instance");
+        }
+
+        return $collector;
     }
 
     /**

--- a/tests/Unit/Debugger/DebuggerTest.php
+++ b/tests/Unit/Debugger/DebuggerTest.php
@@ -117,6 +117,9 @@ class DebuggerTest extends AppTestCase
         $this->debugBarMock->shouldReceive('getJavascriptRenderer')->andReturn($rendererMock);
 
         $this->debugBarMock->shouldReceive('hasCollector')->with(Mockery::any())->andReturn(true);
+        $this->debugBarMock->shouldReceive('getCollector')
+            ->with(Mockery::any())
+            ->andReturn(Mockery::mock(MessagesCollector::class));
 
         $output = $this->debugger->render();
 
@@ -137,7 +140,7 @@ class DebuggerTest extends AppTestCase
         $this->debugBarMock->shouldReceive('hasCollector')
             ->with(Debugger::ROUTES)
             ->andReturn(true);
-        $this->debugBarMock->shouldReceive('offsetGet')
+        $this->debugBarMock->shouldReceive('getCollector')
             ->with(Debugger::ROUTES)
             ->andReturn($collectorMock);
 

--- a/tests/Unit/Debugger/DebuggerTest.php
+++ b/tests/Unit/Debugger/DebuggerTest.php
@@ -108,7 +108,7 @@ class DebuggerTest extends AppTestCase
 
         $this->debugger->initStore();
 
-        $rendererMock = Mockery::mock('alias:' . JavascriptRenderer::class);
+        $rendererMock = Mockery::mock(JavascriptRenderer::class);
         $rendererMock->shouldReceive('setBaseUrl')->andReturnSelf();
         $rendererMock->shouldReceive('addAssets')->andReturnSelf();
         $rendererMock->shouldReceive('renderHead')->andReturn('<head></head>');
@@ -122,6 +122,33 @@ class DebuggerTest extends AppTestCase
 
         $this->assertStringContainsString('<head></head>', $output);
         $this->assertStringContainsString('<div>Debug Bar</div>', $output);
+    }
+
+    public function testDebugbarRenderReplaysArrayPayloadsThroughLog(): void
+    {
+        $this->debugger->initStore();
+        $this->debugger->addToStoreCell(Debugger::ROUTES, LogLevel::INFO, ['Route' => '/welcome']);
+
+        $collectorMock = Mockery::mock(MessagesCollector::class);
+        $collectorMock->shouldReceive('log')
+            ->once()
+            ->with(LogLevel::INFO, ['Route' => '/welcome']);
+
+        $this->debugBarMock->shouldReceive('hasCollector')
+            ->with(Debugger::ROUTES)
+            ->andReturn(true);
+        $this->debugBarMock->shouldReceive('offsetGet')
+            ->with(Debugger::ROUTES)
+            ->andReturn($collectorMock);
+
+        $method = new \ReflectionMethod($this->debugger, 'createTab');
+        $method->setAccessible(true);
+        $method->invoke($this->debugger, Debugger::ROUTES);
+
+        $this->assertEquals(
+            ['info' => ['Route' => '/welcome']],
+            $this->debuggerStore->get(Debugger::ROUTES)[0]
+        );
     }
 
     public function testDebugbarRenderReturnsEmptyWhenDisabled(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debugger message recording so array-style payloads are preserved and displayed correctly in the debug output.
  * Fixed cases where debugger information might not render reliably, improving consistency of the debug bar’s logged messages across tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->