### PR TITLE
Issue/534 http client curl adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog.
 - Added adapter-based Lang provider support with `DeepL` and `Google Translate` adapters plus shared remote request/caching infrastructure (#533)
 
 ### Changed
+- Refactored `HttpClient` internals behind explicit `CurlAdapter` and `MultiCurlAdapter` wrappers while preserving the existing facade methods and keeping `php-curl-class` as the underlying transport for this phase (#534)
 - Refactored the Lang package to resolve adapter instances through `LangFactory` configuration and load file translations lazily on first use instead of preloading them during web boot (#533)
 - **BREAKING:** Reshaped Lang configuration so `lang.default` now selects the adapter, locale fallback moved to `lang.default_locale`, and the unused `lang.enabled` toggle was removed (#533)
 - **BREAKING:** Removed `Lang::isEnabled()` from the public Lang API because it no longer affected runtime behavior (#533)

--- a/src/HttpClient/Adapters/CurlAdapter.php
+++ b/src/HttpClient/Adapters/CurlAdapter.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Quantum PHP Framework
+ * An open-source software development framework for PHP
+ * @link https://quantumphp.io
+ */
+
+namespace Quantum\HttpClient\Adapters;
+
+use Quantum\HttpClient\Contracts\CurlAdapterInterface;
+use Curl\Curl;
+
+/**
+ * Class CurlAdapter
+ * @package Quantum\HttpClient
+ */
+class CurlAdapter implements CurlAdapterInterface
+{
+    private Curl $client;
+
+    public function __construct(?Curl $client = null)
+    {
+        $this->client = $client ?? new Curl();
+    }
+
+    public function setUrl(string $url): CurlAdapterInterface
+    {
+        $this->client->setUrl($url);
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setOpt(int $option, $value): CurlAdapterInterface
+    {
+        $this->client->setOpt($option, $value);
+
+        return $this;
+    }
+
+    /**
+     * @param array<int, mixed> $options
+     */
+    public function setOpts(array $options): CurlAdapterInterface
+    {
+        $this->client->setOpts($options);
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setHeader(string $key, $value): CurlAdapterInterface
+    {
+        $this->client->setHeader($key, $value);
+
+        return $this;
+    }
+
+    /**
+     * @param array<int|string, mixed> $headers
+     */
+    public function setHeaders(array $headers): CurlAdapterInterface
+    {
+        $this->client->setHeaders($headers);
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $data
+     * @return mixed
+     */
+    public function buildPostData($data)
+    {
+        return $this->client->buildPostData($data);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function start()
+    {
+        return $this->client->exec();
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getId()
+    {
+        return $this->client->getId();
+    }
+
+    public function isError(): bool
+    {
+        return $this->client->isError();
+    }
+
+    public function getErrorCode(): int
+    {
+        return $this->client->getErrorCode();
+    }
+
+    public function getErrorMessage(): ?string
+    {
+        return $this->client->getErrorMessage();
+    }
+
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function getResponseHeaders(): iterable
+    {
+        return $this->client->getResponseHeaders();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getResponseCookies()
+    {
+        return $this->client->getResponseCookies();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getResponse()
+    {
+        return $this->client->getResponse();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getInfo(?int $option = null)
+    {
+        return $option ? $this->client->getInfo($option) : $this->client->getInfo();
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->client->getUrl();
+    }
+
+    public function supportsMethod(string $method): bool
+    {
+        return method_exists($this->client, $method);
+    }
+
+    /**
+     * @param array<mixed> $arguments
+     * @return mixed
+     */
+    public function callMethod(string $method, array $arguments)
+    {
+        return $this->client->$method(...$arguments);
+    }
+}

--- a/src/HttpClient/Adapters/CurlAdapter.php
+++ b/src/HttpClient/Adapters/CurlAdapter.php
@@ -142,7 +142,7 @@ class CurlAdapter implements CurlAdapterInterface
      */
     public function getInfo(?int $option = null)
     {
-        return $option ? $this->client->getInfo($option) : $this->client->getInfo();
+        return $option !== null ? $this->client->getInfo($option) : $this->client->getInfo();
     }
 
     public function getUrl(): ?string

--- a/src/HttpClient/Adapters/MultiCurlAdapter.php
+++ b/src/HttpClient/Adapters/MultiCurlAdapter.php
@@ -38,14 +38,18 @@ class MultiCurlAdapter implements MultiCurlAdapterInterface
 
     public function success(callable $callback): MultiCurlAdapterInterface
     {
-        $this->client->success($callback);
+        $this->client->success(function (Curl $instance) use ($callback): void {
+            $callback(new CurlAdapter($instance));
+        });
 
         return $this;
     }
 
     public function error(callable $callback): MultiCurlAdapterInterface
     {
-        $this->client->error($callback);
+        $this->client->error(function (Curl $instance) use ($callback): void {
+            $callback(new CurlAdapter($instance));
+        });
 
         return $this;
     }

--- a/src/HttpClient/Adapters/MultiCurlAdapter.php
+++ b/src/HttpClient/Adapters/MultiCurlAdapter.php
@@ -12,6 +12,7 @@ namespace Quantum\HttpClient\Adapters;
 
 use Quantum\HttpClient\Contracts\MultiCurlAdapterInterface;
 use Curl\MultiCurl;
+use Curl\Curl;
 
 /**
  * Class MultiCurlAdapter
@@ -28,7 +29,9 @@ class MultiCurlAdapter implements MultiCurlAdapterInterface
 
     public function complete(callable $callback): MultiCurlAdapterInterface
     {
-        $this->client->complete($callback);
+        $this->client->complete(function (Curl $instance) use ($callback): void {
+            $callback(new CurlAdapter($instance));
+        });
 
         return $this;
     }

--- a/src/HttpClient/Adapters/MultiCurlAdapter.php
+++ b/src/HttpClient/Adapters/MultiCurlAdapter.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Quantum PHP Framework
+ * An open-source software development framework for PHP
+ * @link https://quantumphp.io
+ */
+
+namespace Quantum\HttpClient\Adapters;
+
+use Quantum\HttpClient\Contracts\MultiCurlAdapterInterface;
+use Curl\MultiCurl;
+
+/**
+ * Class MultiCurlAdapter
+ * @package Quantum\HttpClient
+ */
+class MultiCurlAdapter implements MultiCurlAdapterInterface
+{
+    private MultiCurl $client;
+
+    public function __construct(?MultiCurl $client = null)
+    {
+        $this->client = $client ?? new MultiCurl();
+    }
+
+    public function complete(callable $callback): MultiCurlAdapterInterface
+    {
+        $this->client->complete($callback);
+
+        return $this;
+    }
+
+    public function success(callable $callback): MultiCurlAdapterInterface
+    {
+        $this->client->success($callback);
+
+        return $this;
+    }
+
+    public function error(callable $callback): MultiCurlAdapterInterface
+    {
+        $this->client->error($callback);
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function start()
+    {
+        return $this->client->start();
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return mixed
+     */
+    public function addGet(string $url, array $data = [])
+    {
+        return $this->client->addGet($url, $data);
+    }
+
+    /**
+     * @param mixed $data
+     * @return mixed
+     */
+    public function addPost(string $url, $data = '', bool $follow_303_with_post = false)
+    {
+        return $this->client->addPost($url, $data, $follow_303_with_post);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setHeader(string $key, $value): MultiCurlAdapterInterface
+    {
+        $this->client->setHeader($key, $value);
+
+        return $this;
+    }
+
+    /**
+     * @param array<int|string, mixed> $headers
+     */
+    public function setHeaders(array $headers): MultiCurlAdapterInterface
+    {
+        $this->client->setHeaders($headers);
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setOpt(int $option, $value): MultiCurlAdapterInterface
+    {
+        $this->client->setOpt($option, $value);
+
+        return $this;
+    }
+
+    /**
+     * @param array<int, mixed> $options
+     */
+    public function setOpts(array $options): MultiCurlAdapterInterface
+    {
+        $this->client->setOpts($options);
+
+        return $this;
+    }
+
+    public function supportsMethod(string $method): bool
+    {
+        return method_exists($this->client, $method);
+    }
+
+    /**
+     * @param array<mixed> $arguments
+     * @return mixed
+     */
+    public function callMethod(string $method, array $arguments)
+    {
+        return $this->client->$method(...$arguments);
+    }
+}

--- a/src/HttpClient/Adapters/MultiCurlAdapter.php
+++ b/src/HttpClient/Adapters/MultiCurlAdapter.php
@@ -64,7 +64,7 @@ class MultiCurlAdapter implements MultiCurlAdapterInterface
      */
     public function addGet(string $url, array $data = [])
     {
-        return $this->client->addGet($url, $data);
+        return $this->wrapCurlResult($this->client->addGet($url, $data));
     }
 
     /**
@@ -73,7 +73,7 @@ class MultiCurlAdapter implements MultiCurlAdapterInterface
      */
     public function addPost(string $url, $data = '', bool $follow_303_with_post = false)
     {
-        return $this->client->addPost($url, $data, $follow_303_with_post);
+        return $this->wrapCurlResult($this->client->addPost($url, $data, $follow_303_with_post));
     }
 
     /**
@@ -128,5 +128,14 @@ class MultiCurlAdapter implements MultiCurlAdapterInterface
     public function callMethod(string $method, array $arguments)
     {
         return $this->client->$method(...$arguments);
+    }
+
+    /**
+     * @param mixed $result
+     * @return mixed
+     */
+    private function wrapCurlResult($result)
+    {
+        return $result instanceof Curl ? new CurlAdapter($result) : $result;
     }
 }

--- a/src/HttpClient/Contracts/CurlAdapterInterface.php
+++ b/src/HttpClient/Contracts/CurlAdapterInterface.php
@@ -16,4 +16,65 @@ namespace Quantum\HttpClient\Contracts;
  */
 interface CurlAdapterInterface extends HttpClientAdapterInterface
 {
+    /**
+     * Sets request URL
+     */
+    public function setUrl(string $url): self;
+
+    /**
+     * Builds post data
+     * @param mixed $data
+     * @return mixed
+     */
+    public function buildPostData($data);
+
+    /**
+     * Gets request id
+     * @return int|string
+     */
+    public function getId();
+
+    /**
+     * Checks if request has error
+     */
+    public function isError(): bool;
+
+    /**
+     * Gets error code
+     */
+    public function getErrorCode(): int;
+
+    /**
+     * Gets error message
+     */
+    public function getErrorMessage(): ?string;
+
+    /**
+     * Gets response headers
+     * @return iterable<string, mixed>
+     */
+    public function getResponseHeaders(): iterable;
+
+    /**
+     * Gets response cookies
+     * @return mixed
+     */
+    public function getResponseCookies();
+
+    /**
+     * Gets response
+     * @return mixed
+     */
+    public function getResponse();
+
+    /**
+     * Gets curl info
+     * @return mixed
+     */
+    public function getInfo(?int $option = null);
+
+    /**
+     * Gets request URL
+     */
+    public function getUrl(): ?string;
 }

--- a/src/HttpClient/Contracts/CurlAdapterInterface.php
+++ b/src/HttpClient/Contracts/CurlAdapterInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Quantum PHP Framework
+ * An open-source software development framework for PHP
+ * @link https://quantumphp.io
+ */
+
+namespace Quantum\HttpClient\Contracts;
+
+/**
+ * Interface CurlAdapterInterface
+ * @package Quantum\HttpClient
+ */
+interface CurlAdapterInterface extends HttpClientAdapterInterface
+{
+}

--- a/src/HttpClient/Contracts/HttpClientAdapterInterface.php
+++ b/src/HttpClient/Contracts/HttpClientAdapterInterface.php
@@ -16,4 +16,45 @@ namespace Quantum\HttpClient\Contracts;
  */
 interface HttpClientAdapterInterface
 {
+    /**
+     * Starts request execution
+     * @return mixed
+     */
+    public function start();
+
+    /**
+     * Sets request header
+     * @param mixed $value
+     */
+    public function setHeader(string $key, $value): self;
+
+    /**
+     * Sets request headers
+     * @param array<int|string, mixed> $headers
+     */
+    public function setHeaders(array $headers): self;
+
+    /**
+     * Sets request option
+     * @param mixed $value
+     */
+    public function setOpt(int $option, $value): self;
+
+    /**
+     * Sets multiple request options
+     * @param array<int, mixed> $options
+     */
+    public function setOpts(array $options): self;
+
+    /**
+     * Checks if adapter supports method passthrough
+     */
+    public function supportsMethod(string $method): bool;
+
+    /**
+     * Calls supported adapter method
+     * @param array<mixed> $arguments
+     * @return mixed
+     */
+    public function callMethod(string $method, array $arguments);
 }

--- a/src/HttpClient/Contracts/HttpClientAdapterInterface.php
+++ b/src/HttpClient/Contracts/HttpClientAdapterInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Quantum PHP Framework
+ * An open-source software development framework for PHP
+ * @link https://quantumphp.io
+ */
+
+namespace Quantum\HttpClient\Contracts;
+
+/**
+ * Interface HttpClientAdapterInterface
+ * @package Quantum\HttpClient
+ */
+interface HttpClientAdapterInterface
+{
+}

--- a/src/HttpClient/Contracts/MultiCurlAdapterInterface.php
+++ b/src/HttpClient/Contracts/MultiCurlAdapterInterface.php
@@ -16,4 +16,33 @@ namespace Quantum\HttpClient\Contracts;
  */
 interface MultiCurlAdapterInterface extends HttpClientAdapterInterface
 {
+    /**
+     * Registers complete callback
+     */
+    public function complete(callable $callback): self;
+
+    /**
+     * Registers success callback
+     */
+    public function success(callable $callback): self;
+
+    /**
+     * Registers error callback
+     */
+    public function error(callable $callback): self;
+
+    /**
+     * Adds GET request
+     * @param array<string, mixed> $data
+     * @return mixed
+     */
+    public function addGet(string $url, array $data = []);
+
+    /**
+     * Adds POST request
+     * @param mixed $data
+     * @return mixed
+     */
+    public function addPost(string $url, $data = '', bool $follow_303_with_post = false);
+
 }

--- a/src/HttpClient/Contracts/MultiCurlAdapterInterface.php
+++ b/src/HttpClient/Contracts/MultiCurlAdapterInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Quantum PHP Framework
+ * An open-source software development framework for PHP
+ * @link https://quantumphp.io
+ */
+
+namespace Quantum\HttpClient\Contracts;
+
+/**
+ * Interface MultiCurlAdapterInterface
+ * @package Quantum\HttpClient
+ */
+interface MultiCurlAdapterInterface extends HttpClientAdapterInterface
+{
+}

--- a/src/HttpClient/Enums/HttpClientType.php
+++ b/src/HttpClient/Enums/HttpClientType.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Quantum PHP Framework
+ * An open-source software development framework for PHP
+ * @link https://quantumphp.io
+ */
+
+namespace Quantum\HttpClient\Enums;
+
+/**
+ * Class HttpClientType
+ * @package Quantum\HttpClient
+ * @codeCoverageIgnore
+ */
+final class HttpClientType
+{
+    public const CURL = 'curl';
+
+    public const MULTI_CURL = 'multi_curl';
+
+    private function __construct()
+    {
+    }
+}

--- a/src/HttpClient/Factories/HttpClientFactory.php
+++ b/src/HttpClient/Factories/HttpClientFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Quantum PHP Framework
+ * An open-source software development framework for PHP
+ * @link https://quantumphp.io
+ */
+
+namespace Quantum\HttpClient\Factories;
+
+use Quantum\App\Exceptions\BaseException;
+use Quantum\Di\Exceptions\DiException;
+use Quantum\HttpClient\HttpClient;
+use Quantum\Di\Di;
+use ReflectionException;
+
+/**
+ * Class HttpClientFactory
+ * @package Quantum\HttpClient
+ */
+class HttpClientFactory
+{
+    private ?HttpClient $instance = null;
+
+    /**
+     * @throws DiException|BaseException|ReflectionException
+     */
+    public static function get(): HttpClient
+    {
+        if (!Di::isRegistered(self::class)) {
+            Di::register(self::class);
+        }
+
+        return Di::get(self::class)->resolve();
+    }
+
+    public function resolve(): HttpClient
+    {
+        if (!$this->instance) {
+            $this->instance = $this->createInstance();
+        }
+
+        return $this->instance;
+    }
+
+    private function createInstance(): HttpClient
+    {
+        return new HttpClient();
+    }
+}

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -10,9 +10,13 @@ declare(strict_types=1);
 
 namespace Quantum\HttpClient;
 
+use Quantum\HttpClient\Contracts\HttpClientAdapterInterface;
+use Quantum\HttpClient\Contracts\MultiCurlAdapterInterface;
+use Quantum\HttpClient\Contracts\CurlAdapterInterface;
 use Quantum\HttpClient\Exceptions\HttpClientException;
+use Quantum\HttpClient\Adapters\MultiCurlAdapter;
+use Quantum\HttpClient\Adapters\CurlAdapter;
 use Quantum\App\Exceptions\BaseException;
-use Curl\CaseInsensitiveArray;
 use Curl\MultiCurl;
 use ErrorException;
 use Curl\Curl;
@@ -20,7 +24,6 @@ use Curl\Curl;
 /**
  * HttpClient Class
  * @package Quantum\HttpClient
- * @uses php-curl-class/php-curl-class
  * @method object addGet(string $url, array<string, mixed> $data = [])
  * @method object addPost(string $url, string $data = '', bool $follow_303_with_post = false)
  * @method setHeader($key, $value)
@@ -50,9 +53,9 @@ class HttpClient
     public const RESPONSE_BODY = 'body';
 
     /**
-     * @var MultiCurl|Curl
+     * @var HttpClientAdapterInterface|null
      */
-    private Curl|MultiCurl|null $client = null;
+    private ?HttpClientAdapterInterface $client = null;
 
     private string $method = 'GET';
 
@@ -68,12 +71,12 @@ class HttpClient
     private array $requestHeaders = [];
 
     /**
-     * @var array<string, mixed>
+     * @var array<int|string, mixed>
      */
     private array $response = [];
 
     /**
-     * @var array<string, mixed>
+     * @var array<int|string, mixed>
      */
     private array $errors = [];
 
@@ -82,8 +85,11 @@ class HttpClient
      */
     public function createRequest(string $url, ?Curl $client = null): HttpClient
     {
-        $this->client = $client ?: new Curl();
-        $this->client->setUrl($url);
+        $adapter = new CurlAdapter($client);
+        $adapter->setUrl($url);
+
+        $this->client = $adapter;
+
         return $this;
     }
 
@@ -92,11 +98,13 @@ class HttpClient
      */
     public function createMultiRequest(?MultiCurl $client = null): HttpClient
     {
-        $this->client = $client ?: new MultiCurl();
+        $adapter = new MultiCurlAdapter($client);
 
-        $this->client->complete(function (Curl $instance): void {
+        $adapter->complete(function (CurlAdapterInterface $instance): void {
             $this->handleResponse($instance);
         });
+
+        $this->client = $adapter;
 
         return $this;
     }
@@ -106,12 +114,22 @@ class HttpClient
      */
     public function createAsyncMultiRequest(callable $success, callable $error, ?MultiCurl $client = null): HttpClient
     {
-        $this->client = $client ?: new MultiCurl();
+        $adapter = new MultiCurlAdapter($client);
 
-        $this->client->success($success);
-        $this->client->error($error);
+        $adapter->success($success);
+        $adapter->error($error);
+
+        $this->client = $adapter;
 
         return $this;
+    }
+
+    /**
+     * Gets the current adapter
+     */
+    public function getAdapter(): ?HttpClientAdapterInterface
+    {
+        return $this->client;
     }
 
     /**
@@ -157,12 +175,12 @@ class HttpClient
 
     /**
      * Checks if the request is multi cURL
-     * @phpstan-assert-if-true MultiCurl $this->client
-     * @phpstan-assert-if-false Curl $this->client
+     * @phpstan-assert-if-true MultiCurlAdapterInterface $this->client
+     * @phpstan-assert-if-false CurlAdapterInterface $this->client
      */
     public function isMultiRequest(): bool
     {
-        return $this->client instanceof MultiCurl;
+        return $this->client instanceof MultiCurlAdapterInterface;
     }
 
     /**
@@ -251,20 +269,28 @@ class HttpClient
 
     /**
      * Gets the entire response
-     * @return array<string, mixed>
+     * @return array<int|string, mixed>
      */
     public function getResponse(): array
     {
-        return $this->isMultiRequest() ? $this->response : ($this->response[$this->client->getId()] ?? []);
+        if ($this->isMultiRequest()) {
+            return $this->response;
+        }
+
+        return $this->response[$this->client->getId()] ?? [];
     }
 
     /**
      * Returns the errors
-     * @return array<string, mixed>
+     * @return array<int|string, mixed>
      */
     public function getErrors(): array
     {
-        return $this->isMultiRequest() ? $this->errors : ($this->errors[$this->client->getId()] ?? []);
+        if ($this->isMultiRequest()) {
+            return $this->errors;
+        }
+
+        return $this->errors[$this->client->getId()] ?? [];
     }
 
     /**
@@ -297,17 +323,17 @@ class HttpClient
      */
     public function __call(string $method, array $arguments): HttpClient
     {
-        if (is_null($this->client)) {
-            throw HttpClientException::requestNotCreated();
-        }
+        $this->ensureRequestCreated();
 
-        if (!method_exists($this->client, $method)) {
+        if (!$this->client->supportsMethod($method)) {
             throw HttpClientException::methodNotSupported($method, $this->client::class);
         }
 
         $this->interceptCall($method, $arguments);
 
-        $this->client->$method(...$arguments);
+        $this->ensureRequestCreated();
+
+        $this->client->callMethod($method, $arguments);
 
         return $this;
     }
@@ -325,14 +351,14 @@ class HttpClient
             $this->client->setOpt(CURLOPT_POSTFIELDS, $this->client->buildPostData($this->data));
         }
 
-        $this->client->exec();
+        $this->client->start();
         $this->handleResponse($this->client);
     }
 
     /**
      * Handles the response
      */
-    private function handleResponse(Curl $instance): void
+    private function handleResponse(CurlAdapterInterface $instance): void
     {
         if ($instance->isError()) {
             $this->errors[$instance->getId()] = [
@@ -349,9 +375,10 @@ class HttpClient
     }
 
     /**
+     * @param iterable<string, mixed> $headers
      * @return array<string, mixed>
      */
-    private function formatHeaders(CaseInsensitiveArray $headers): array
+    private function formatHeaders(iterable $headers): array
     {
         $formatted = [];
 
@@ -364,12 +391,23 @@ class HttpClient
 
     /**
      * @throws BaseException
-     * @phpstan-assert Curl $this->client
+     * @phpstan-assert CurlAdapterInterface $this->client
      */
     private function ensureSingleRequest(): void
     {
         if ($this->isMultiRequest()) {
-            throw HttpClientException::methodNotSupported(__METHOD__, MultiCurl::class);
+            throw HttpClientException::methodNotSupported(__METHOD__, MultiCurlAdapter::class);
+        }
+    }
+
+    /**
+     * @throws HttpClientException
+     * @phpstan-assert HttpClientAdapterInterface $this->client
+     */
+    private function ensureRequestCreated(): void
+    {
+        if ($this->client === null) {
+            throw HttpClientException::requestNotCreated();
         }
     }
 

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -403,6 +403,8 @@ class HttpClient
      */
     private function ensureSingleRequest(): void
     {
+        $this->ensureRequestCreated();
+
         if ($this->isMultiRequest()) {
             throw HttpClientException::methodNotSupported(__METHOD__, MultiCurlAdapter::class);
         }

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -310,7 +310,7 @@ class HttpClient
     {
         $this->ensureSingleRequest();
 
-        return $option ? $this->client->getInfo($option) : $this->client->getInfo();
+        return $option !== null ? $this->client->getInfo($option) : $this->client->getInfo();
     }
 
     /**

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -270,11 +270,12 @@ class HttpClient
     /**
      * Gets the entire response
      * @return array<int|string, mixed>
-     * @throws BaseException
      */
     public function getResponse(): array
     {
-        $this->ensureRequestCreated();
+        if ($this->client === null) {
+            return [];
+        }
 
         if ($this->isMultiRequest()) {
             return $this->response;
@@ -286,11 +287,12 @@ class HttpClient
     /**
      * Returns the errors
      * @return array<int|string, mixed>
-     * @throws BaseException
      */
     public function getErrors(): array
     {
-        $this->ensureRequestCreated();
+        if ($this->client === null) {
+            return [];
+        }
 
         if ($this->isMultiRequest()) {
             return $this->errors;

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -176,7 +176,7 @@ class HttpClient
     /**
      * Checks if the request is multi cURL
      * @phpstan-assert-if-true MultiCurlAdapterInterface $this->client
-     * @phpstan-assert-if-false CurlAdapterInterface $this->client
+     * @phpstan-assert-if-false CurlAdapterInterface|null $this->client
      */
     public function isMultiRequest(): bool
     {
@@ -270,9 +270,12 @@ class HttpClient
     /**
      * Gets the entire response
      * @return array<int|string, mixed>
+     * @throws BaseException
      */
     public function getResponse(): array
     {
+        $this->ensureRequestCreated();
+
         if ($this->isMultiRequest()) {
             return $this->response;
         }
@@ -283,9 +286,12 @@ class HttpClient
     /**
      * Returns the errors
      * @return array<int|string, mixed>
+     * @throws BaseException
      */
     public function getErrors(): array
     {
+        $this->ensureRequestCreated();
+
         if ($this->isMultiRequest()) {
             return $this->errors;
         }

--- a/tests/Unit/HttpClient/Adapters/CurlAdapterTest.php
+++ b/tests/Unit/HttpClient/Adapters/CurlAdapterTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Quantum\Tests\Unit\HttpClient\Adapters;
+
+use Quantum\HttpClient\Adapters\CurlAdapter;
+use Quantum\Tests\Unit\AppTestCase;
+use Curl\CaseInsensitiveArray;
+use Curl\Curl;
+use Mockery;
+
+class CurlAdapterTest extends AppTestCase
+{
+    public function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function testCurlAdapterDelegatesRequestMethods(): void
+    {
+        $curl = Mockery::mock(Curl::class);
+        $curl->shouldReceive('setUrl')->once()->with('https://example.com');
+        $curl->shouldReceive('setHeader')->once()->with('Accept', 'application/json');
+        $curl->shouldReceive('setHeaders')->once()->with(['X-Test' => 'yes']);
+        $curl->shouldReceive('setOpt')->once()->with(CURLOPT_TIMEOUT, 10);
+        $curl->shouldReceive('setOpts')->once()->with([CURLOPT_CONNECTTIMEOUT => 5]);
+        $curl->shouldReceive('buildPostData')->once()->with(['a' => 1])->andReturn('a=1');
+        $curl->shouldReceive('exec')->once()->andReturn('ok');
+
+        $adapter = new CurlAdapter($curl);
+
+        $this->assertSame($adapter, $adapter->setUrl('https://example.com'));
+        $this->assertSame($adapter, $adapter->setHeader('Accept', 'application/json'));
+        $this->assertSame($adapter, $adapter->setHeaders(['X-Test' => 'yes']));
+        $this->assertSame($adapter, $adapter->setOpt(CURLOPT_TIMEOUT, 10));
+        $this->assertSame($adapter, $adapter->setOpts([CURLOPT_CONNECTTIMEOUT => 5]));
+        $this->assertSame('a=1', $adapter->buildPostData(['a' => 1]));
+        $this->assertSame('ok', $adapter->start());
+    }
+
+    public function testCurlAdapterDelegatesResponseMethods(): void
+    {
+        $headers = new CaseInsensitiveArray(['Content-Type' => 'application/json']);
+        $response = (object) ['ok' => true];
+
+        $curl = Mockery::mock(Curl::class);
+        $curl->shouldReceive('getId')->once()->andReturn(7);
+        $curl->shouldReceive('isError')->once()->andReturn(false);
+        $curl->shouldReceive('getErrorCode')->once()->andReturn(0);
+        $curl->shouldReceive('getErrorMessage')->once()->andReturn(null);
+        $curl->shouldReceive('getResponseHeaders')->once()->andReturn($headers);
+        $curl->shouldReceive('getResponseCookies')->once()->andReturn(['sid' => 'abc']);
+        $curl->shouldReceive('getResponse')->once()->andReturn($response);
+        $curl->shouldReceive('getInfo')->with(CURLINFO_HTTP_CODE)->once()->andReturn(200);
+        $curl->shouldReceive('getUrl')->once()->andReturn('https://example.com');
+
+        $adapter = new CurlAdapter($curl);
+
+        $this->assertSame(7, $adapter->getId());
+        $this->assertFalse($adapter->isError());
+        $this->assertSame(0, $adapter->getErrorCode());
+        $this->assertNull($adapter->getErrorMessage());
+        $this->assertSame($headers, $adapter->getResponseHeaders());
+        $this->assertSame(['sid' => 'abc'], $adapter->getResponseCookies());
+        $this->assertSame($response, $adapter->getResponse());
+        $this->assertSame(200, $adapter->getInfo(CURLINFO_HTTP_CODE));
+        $this->assertSame('https://example.com', $adapter->getUrl());
+    }
+
+    public function testCurlAdapterSupportsAndCallsVendorMethods(): void
+    {
+        $curl = Mockery::mock(Curl::class);
+        $curl->shouldReceive('setTimeout')->once()->with(15)->andReturnNull();
+
+        $adapter = new CurlAdapter($curl);
+
+        $this->assertTrue($adapter->supportsMethod('setTimeout'));
+        $this->assertFalse($adapter->supportsMethod('missingMethod'));
+        $this->assertNull($adapter->callMethod('setTimeout', [15]));
+    }
+}

--- a/tests/Unit/HttpClient/Adapters/CurlAdapterTest.php
+++ b/tests/Unit/HttpClient/Adapters/CurlAdapterTest.php
@@ -68,6 +68,16 @@ class CurlAdapterTest extends AppTestCase
         $this->assertSame('https://example.com', $adapter->getUrl());
     }
 
+    public function testCurlAdapterPassesZeroInfoOption(): void
+    {
+        $curl = Mockery::mock(Curl::class);
+        $curl->shouldReceive('getInfo')->with(0)->once()->andReturn('zero');
+
+        $adapter = new CurlAdapter($curl);
+
+        $this->assertSame('zero', $adapter->getInfo(0));
+    }
+
     public function testCurlAdapterSupportsAndCallsVendorMethods(): void
     {
         $curl = Mockery::mock(Curl::class);

--- a/tests/Unit/HttpClient/Adapters/MultiCurlAdapterTest.php
+++ b/tests/Unit/HttpClient/Adapters/MultiCurlAdapterTest.php
@@ -45,17 +45,32 @@ class MultiCurlAdapterTest extends AppTestCase
 
     public function testMultiCurlAdapterRegistersCallbacks(): void
     {
-        $success = fn () => null;
-        $error = fn () => null;
+        $curl = Mockery::mock(Curl::class);
 
         $multiCurl = Mockery::mock(MultiCurl::class);
-        $multiCurl->shouldReceive('success')->once()->with($success)->andReturnNull();
-        $multiCurl->shouldReceive('error')->once()->with($error)->andReturnNull();
+        $multiCurl->shouldReceive('success')
+            ->once()
+            ->andReturnUsing(function (callable $callback) use ($curl): void {
+                $callback($curl);
+            });
+        $multiCurl->shouldReceive('error')
+            ->once()
+            ->andReturnUsing(function (callable $callback) use ($curl): void {
+                $callback($curl);
+            });
 
         $adapter = new MultiCurlAdapter($multiCurl);
+        $successWrapped = null;
+        $errorWrapped = null;
 
-        $this->assertSame($adapter, $adapter->success($success));
-        $this->assertSame($adapter, $adapter->error($error));
+        $this->assertSame($adapter, $adapter->success(function (CurlAdapter $instance) use (&$successWrapped): void {
+            $successWrapped = $instance;
+        }));
+        $this->assertSame($adapter, $adapter->error(function (CurlAdapter $instance) use (&$errorWrapped): void {
+            $errorWrapped = $instance;
+        }));
+        $this->assertInstanceOf(CurlAdapter::class, $successWrapped);
+        $this->assertInstanceOf(CurlAdapter::class, $errorWrapped);
     }
 
     public function testMultiCurlAdapterWrapsCompleteCallbackInstance(): void

--- a/tests/Unit/HttpClient/Adapters/MultiCurlAdapterTest.php
+++ b/tests/Unit/HttpClient/Adapters/MultiCurlAdapterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Quantum\Tests\Unit\HttpClient\Adapters;
+
+use Quantum\HttpClient\Adapters\MultiCurlAdapter;
+use Quantum\HttpClient\Adapters\CurlAdapter;
+use Quantum\Tests\Unit\AppTestCase;
+use Curl\MultiCurl;
+use Curl\Curl;
+use Mockery;
+
+class MultiCurlAdapterTest extends AppTestCase
+{
+    public function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function testMultiCurlAdapterDelegatesRequestMethods(): void
+    {
+        $multiCurl = Mockery::mock(MultiCurl::class);
+        $multiCurl->shouldReceive('setHeader')->once()->with('Accept', 'application/json');
+        $multiCurl->shouldReceive('setHeaders')->once()->with(['X-Test' => 'yes']);
+        $multiCurl->shouldReceive('setOpt')->once()->with(CURLOPT_TIMEOUT, 10);
+        $multiCurl->shouldReceive('setOpts')->once()->with([CURLOPT_CONNECTTIMEOUT => 5]);
+        $multiCurl->shouldReceive('addGet')->once()->with('https://example.com', ['a' => 1])->andReturn((object) ['id' => 1]);
+        $multiCurl->shouldReceive('addPost')->once()->with('https://example.com', 'payload', true)->andReturn((object) ['id' => 2]);
+        $multiCurl->shouldReceive('start')->once()->andReturnNull();
+
+        $adapter = new MultiCurlAdapter($multiCurl);
+
+        $this->assertSame($adapter, $adapter->setHeader('Accept', 'application/json'));
+        $this->assertSame($adapter, $adapter->setHeaders(['X-Test' => 'yes']));
+        $this->assertSame($adapter, $adapter->setOpt(CURLOPT_TIMEOUT, 10));
+        $this->assertSame($adapter, $adapter->setOpts([CURLOPT_CONNECTTIMEOUT => 5]));
+        $this->assertEquals((object) ['id' => 1], $adapter->addGet('https://example.com', ['a' => 1]));
+        $this->assertEquals((object) ['id' => 2], $adapter->addPost('https://example.com', 'payload', true));
+        $this->assertNull($adapter->start());
+    }
+
+    public function testMultiCurlAdapterRegistersCallbacks(): void
+    {
+        $success = fn () => null;
+        $error = fn () => null;
+
+        $multiCurl = Mockery::mock(MultiCurl::class);
+        $multiCurl->shouldReceive('success')->once()->with($success)->andReturnNull();
+        $multiCurl->shouldReceive('error')->once()->with($error)->andReturnNull();
+
+        $adapter = new MultiCurlAdapter($multiCurl);
+
+        $this->assertSame($adapter, $adapter->success($success));
+        $this->assertSame($adapter, $adapter->error($error));
+    }
+
+    public function testMultiCurlAdapterWrapsCompleteCallbackInstance(): void
+    {
+        $curl = Mockery::mock(Curl::class);
+
+        $multiCurl = Mockery::mock(MultiCurl::class);
+        $multiCurl->shouldReceive('complete')
+            ->once()
+            ->andReturnUsing(function (callable $callback) use ($curl): void {
+                $callback($curl);
+            });
+
+        $adapter = new MultiCurlAdapter($multiCurl);
+        $wrapped = null;
+
+        $this->assertSame($adapter, $adapter->complete(function (CurlAdapter $instance) use (&$wrapped): void {
+            $wrapped = $instance;
+        }));
+
+        $this->assertInstanceOf(CurlAdapter::class, $wrapped);
+    }
+
+    public function testMultiCurlAdapterSupportsDocumentedMethods(): void
+    {
+        $multiCurl = Mockery::mock(MultiCurl::class);
+        $multiCurl->shouldReceive('addGet')->once()->with('https://example.com', [])->andReturn((object) ['id' => 1]);
+
+        $adapter = new MultiCurlAdapter($multiCurl);
+
+        $this->assertTrue($adapter->supportsMethod('addGet'));
+        $this->assertFalse($adapter->supportsMethod('missingMethod'));
+        $this->assertEquals((object) ['id' => 1], $adapter->callMethod('addGet', ['https://example.com', []]));
+    }
+}

--- a/tests/Unit/HttpClient/Adapters/MultiCurlAdapterTest.php
+++ b/tests/Unit/HttpClient/Adapters/MultiCurlAdapterTest.php
@@ -20,13 +20,16 @@ class MultiCurlAdapterTest extends AppTestCase
 
     public function testMultiCurlAdapterDelegatesRequestMethods(): void
     {
+        $getCurl = Mockery::mock(Curl::class);
+        $postCurl = Mockery::mock(Curl::class);
+
         $multiCurl = Mockery::mock(MultiCurl::class);
         $multiCurl->shouldReceive('setHeader')->once()->with('Accept', 'application/json');
         $multiCurl->shouldReceive('setHeaders')->once()->with(['X-Test' => 'yes']);
         $multiCurl->shouldReceive('setOpt')->once()->with(CURLOPT_TIMEOUT, 10);
         $multiCurl->shouldReceive('setOpts')->once()->with([CURLOPT_CONNECTTIMEOUT => 5]);
-        $multiCurl->shouldReceive('addGet')->once()->with('https://example.com', ['a' => 1])->andReturn((object) ['id' => 1]);
-        $multiCurl->shouldReceive('addPost')->once()->with('https://example.com', 'payload', true)->andReturn((object) ['id' => 2]);
+        $multiCurl->shouldReceive('addGet')->once()->with('https://example.com', ['a' => 1])->andReturn($getCurl);
+        $multiCurl->shouldReceive('addPost')->once()->with('https://example.com', 'payload', true)->andReturn($postCurl);
         $multiCurl->shouldReceive('start')->once()->andReturnNull();
 
         $adapter = new MultiCurlAdapter($multiCurl);
@@ -35,8 +38,8 @@ class MultiCurlAdapterTest extends AppTestCase
         $this->assertSame($adapter, $adapter->setHeaders(['X-Test' => 'yes']));
         $this->assertSame($adapter, $adapter->setOpt(CURLOPT_TIMEOUT, 10));
         $this->assertSame($adapter, $adapter->setOpts([CURLOPT_CONNECTTIMEOUT => 5]));
-        $this->assertEquals((object) ['id' => 1], $adapter->addGet('https://example.com', ['a' => 1]));
-        $this->assertEquals((object) ['id' => 2], $adapter->addPost('https://example.com', 'payload', true));
+        $this->assertInstanceOf(CurlAdapter::class, $adapter->addGet('https://example.com', ['a' => 1]));
+        $this->assertInstanceOf(CurlAdapter::class, $adapter->addPost('https://example.com', 'payload', true));
         $this->assertNull($adapter->start());
     }
 

--- a/tests/Unit/HttpClient/Factories/HttpClientFactoryTest.php
+++ b/tests/Unit/HttpClient/Factories/HttpClientFactoryTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Quantum\Tests\Unit\HttpClient\Factories;
+
+use Quantum\HttpClient\Factories\HttpClientFactory;
+use Quantum\Tests\Unit\AppTestCase;
+use Quantum\HttpClient\HttpClient;
+use Quantum\Di\Di;
+
+class HttpClientFactoryTest extends AppTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->resetHttpClientFactory();
+    }
+
+    public function testHttpClientFactoryInstance(): void
+    {
+        $this->assertInstanceOf(HttpClient::class, HttpClientFactory::get());
+    }
+
+    public function testHttpClientFactoryReturnsSameInstance(): void
+    {
+        $httpClient1 = HttpClientFactory::get();
+        $httpClient2 = HttpClientFactory::get();
+
+        $this->assertSame($httpClient1, $httpClient2);
+    }
+
+    public function testHttpClientFactoryResolveReturnsSameInstance(): void
+    {
+        $factory = Di::get(HttpClientFactory::class);
+
+        $httpClient1 = $factory->resolve();
+        $httpClient2 = $factory->resolve();
+
+        $this->assertSame($httpClient1, $httpClient2);
+    }
+
+    private function resetHttpClientFactory(): void
+    {
+        if (!Di::isRegistered(HttpClientFactory::class)) {
+            Di::register(HttpClientFactory::class);
+        }
+
+        $factory = Di::get(HttpClientFactory::class);
+        $this->setPrivateProperty($factory, 'instance', null);
+    }
+}

--- a/tests/Unit/HttpClient/HttpClientTest.php
+++ b/tests/Unit/HttpClient/HttpClientTest.php
@@ -297,4 +297,15 @@ class HttpClientTest extends AppTestCase
 
         $this->assertEquals('https://example.com', $this->httpClient->url());
     }
+
+    public function testHttpClientPassesZeroInfoOption(): void
+    {
+        $curl = Mockery::mock(Curl::class);
+        $curl->shouldReceive('setUrl')->once();
+        $curl->shouldReceive('getInfo')->with(0)->once()->andReturn('zero');
+
+        $this->httpClient->createRequest('https://example.com', $curl);
+
+        $this->assertSame('zero', $this->httpClient->info(0));
+    }
 }

--- a/tests/Unit/HttpClient/HttpClientTest.php
+++ b/tests/Unit/HttpClient/HttpClientTest.php
@@ -3,6 +3,8 @@
 namespace Quantum\Tests\Unit\HttpClient;
 
 use Quantum\HttpClient\Exceptions\HttpClientException;
+use Quantum\HttpClient\Adapters\MultiCurlAdapter;
+use Quantum\HttpClient\Adapters\CurlAdapter;
 use Quantum\HttpClient\HttpClient;
 use Quantum\Tests\Unit\AppTestCase;
 use Curl\CaseInsensitiveArray;
@@ -66,9 +68,13 @@ class HttpClientTest extends AppTestCase
 
         $this->assertFalse($this->httpClient->isMultiRequest());
 
+        $this->assertInstanceOf(CurlAdapter::class, $this->httpClient->getAdapter());
+
         $this->httpClient->createMultiRequest($multi);
 
         $this->assertTrue($this->httpClient->isMultiRequest());
+
+        $this->assertInstanceOf(MultiCurlAdapter::class, $this->httpClient->getAdapter());
     }
 
     public function testHttpClientRequestNotCreated(): void
@@ -235,6 +241,8 @@ class HttpClientTest extends AppTestCase
         $this->httpClient->createAsyncMultiRequest($success, $error, $multi);
 
         $this->assertTrue($this->httpClient->isMultiRequest());
+
+        $this->assertInstanceOf(MultiCurlAdapter::class, $this->httpClient->getAdapter());
     }
 
     public function testHttpClientInfoAndUrl(): void

--- a/tests/Unit/HttpClient/HttpClientTest.php
+++ b/tests/Unit/HttpClient/HttpClientTest.php
@@ -86,6 +86,13 @@ class HttpClientTest extends AppTestCase
         $this->httpClient->start();
     }
 
+    public function testHttpClientReturnsEmptyResponseAndErrorsBeforeRequestCreated(): void
+    {
+        $this->assertSame([], $this->httpClient->getResponse());
+
+        $this->assertSame([], $this->httpClient->getErrors());
+    }
+
     public function testHttpClientEnsureSingleRequestThrowsOnMulti(): void
     {
         $multi = Mockery::mock(MultiCurl::class);

--- a/tests/Unit/HttpClient/HttpClientTest.php
+++ b/tests/Unit/HttpClient/HttpClientTest.php
@@ -233,18 +233,37 @@ class HttpClientTest extends AppTestCase
 
     public function testHttpClientCreateAsyncMultiRequestRegistersCallbacks(): void
     {
-        $success = fn () => null;
-        $error = fn () => null;
+        $curl = Mockery::mock(Curl::class);
+        $successWrapped = null;
+        $errorWrapped = null;
+        $success = function (CurlAdapter $instance) use (&$successWrapped): void {
+            $successWrapped = $instance;
+        };
+        $error = function (CurlAdapter $instance) use (&$errorWrapped): void {
+            $errorWrapped = $instance;
+        };
 
         $multi = Mockery::mock(MultiCurl::class);
-        $multi->shouldReceive('success')->once()->with($success)->andReturnSelf();
-        $multi->shouldReceive('error')->once()->with($error)->andReturnSelf();
+        $multi->shouldReceive('success')
+            ->once()
+            ->andReturnUsing(function (callable $callback) use ($curl): void {
+                $callback($curl);
+            });
+        $multi->shouldReceive('error')
+            ->once()
+            ->andReturnUsing(function (callable $callback) use ($curl): void {
+                $callback($curl);
+            });
 
         $this->httpClient->createAsyncMultiRequest($success, $error, $multi);
 
         $this->assertTrue($this->httpClient->isMultiRequest());
 
         $this->assertInstanceOf(MultiCurlAdapter::class, $this->httpClient->getAdapter());
+
+        $this->assertInstanceOf(CurlAdapter::class, $successWrapped);
+
+        $this->assertInstanceOf(CurlAdapter::class, $errorWrapped);
     }
 
     public function testHttpClientInfoAndUrl(): void

--- a/tests/Unit/HttpClient/HttpClientTest.php
+++ b/tests/Unit/HttpClient/HttpClientTest.php
@@ -32,6 +32,8 @@ class HttpClientTest extends AppTestCase
 
     public function testHttpClientGetSetMethod(): void
     {
+        $this->assertNull($this->httpClient->getAdapter());
+
         $this->assertEquals('GET', $this->httpClient->getMethod());
 
         $this->httpClient->setMethod('POST');


### PR DESCRIPTION
Closes #534 

This PR separates `HttpClient` execution behind Quantum-owned `CurlAdapter` and `MultiCurlAdapter` wrappers while preserving the existing `HttpClient` facade and keeping `php-curl-class` underneath for this phase.

It does not remove` php-curl-class` yet. That is intentionally deferred so native curl replacement can be implemented and reviewed separately against the adapter contracts introduced here.

Retiring `php-curl-class/php-curl-class` will be handled in follow-up ticket(s).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced adapter-based HTTP handling for both single and multi requests.
  * Added public access to the currently active adapter.
  * Added adapter interfaces and a factory to create/reuse the HTTP client.
  * Added constants for supported HTTP client types.
* **Bug Fixes**
  * Improved compatibility for `info(0)` calls (now verified by tests).
* **Tests**
  * Added/expanded unit tests for adapters, factory, and client behavior.
* **Documentation**
  * Updated the changelog for version 3.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->